### PR TITLE
[#2] reduce the screen flicker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ authors = ["Mark Wallace <lotabout@gmail.com>"]
 libc = "*"
 ncurses = "*"
 getopts = "0.2"
+num_cpus = "0.2"
+crossbeam = "0.2"

--- a/src/curses.rs
+++ b/src/curses.rs
@@ -44,7 +44,6 @@ impl Curses {
         set_term(self.screen);
 
         raw();
-        keypad(stdscr, true);
         noecho();
 
         if let Some(theme) = theme {
@@ -95,11 +94,26 @@ impl Curses {
         }
     }
 
+    pub fn mv(&self, y: i32, x: i32) {
+        mv(y, x);
+    }
+
+    pub fn get_yx(&self) -> (i32, i32) {
+        let mut y = 0;
+        let mut x = 0;
+        getyx(stdscr, &mut y, &mut x);
+        (y, x)
+    }
+
     pub fn get_maxyx(&self) -> (i32, i32) {
         let mut max_y = 0;
         let mut max_x = 0;
         getmaxyx(stdscr, &mut max_y, &mut max_x);
         (max_y, max_x)
+    }
+
+    pub fn clrtoeol(&self) {
+        clrtoeol();
     }
 
     pub fn cprint(&self, text: &str, pair: i16, is_bold: bool) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,31 +91,27 @@ fn real_main() -> i32 {
     });
 
     // model
-    let eb_model = eb.clone();
-    let mut model = Model::new(eb_model, curses);
+    let mut model = Model::new(eb.clone(), curses);
     // parse options for model
     if options.opt_present("m") {model.multi_selection = true;}
     if let Some(prompt) = options.opt_str("p") {model.prompt = prompt;}
 
 
     // matcher
-    let eb_clone = eb.clone();
     let items = model.items.clone();
-    let mut matcher = Matcher::new(items, item_buffer.clone(), eb_clone);
+    let mut matcher = Matcher::new(items, item_buffer.clone(), eb.clone());
     let eb_matcher = matcher.eb_req.clone();
 
     // reader
-    let eb_clone_reader = eb.clone();
     let default_command = match env::var("FZF_DEFAULT_COMMAND") {
         Ok(val) => val,
         Err(_) => "find .".to_string(),
     };
-    let mut reader = Reader::new(default_command, eb_clone_reader, item_buffer);
+    let mut reader = Reader::new(default_command, eb.clone(), item_buffer.clone());
 
 
     // input
-    let eb_clone_input = eb.clone();
-    let mut input = Input::new(eb_clone_input);
+    let mut input = Input::new(eb.clone());
     input.parse_keymap(options.opt_str("b"));
     input.parse_expect_keys(options.opt_str("e"));
 
@@ -135,25 +131,32 @@ fn real_main() -> i32 {
     let mut exit_code = 0;
 
     'outer: loop {
-        let mut need_refresh = true;
         for (e, val) in eb.wait() {
             match e {
                 Event::EvReaderNewItem => {
                     eb_matcher.set(Event::EvMatcherNewItem, Box::new(true));
                     let reading: bool = *val.downcast().unwrap();
                     model.reading = reading;
+
+                    let new_items = item_buffer.read().unwrap();
+                    model.update_num_total(new_items.len());
+                    model.print_info();
                 }
 
                 Event::EvMatcherUpdateProcess => {
                     let percentage: u64 = *val.downcast().unwrap();
-                    model.update_process_info(percentage);
+                    model.update_percentage(percentage);
+                    model.print_info();
                 }
 
                 Event::EvMatcherEnd => {
                     // do nothing
                     let result: OrderedVec<MatchedItem> = *val.downcast().unwrap();
-                    let mut matched_items = model.matched_items.borrow_mut();
-                    *matched_items = result;
+                    {
+                        let mut matched_items = model.matched_items.borrow_mut();
+                        *matched_items = result;
+                    }
+                    model.display();
                 }
 
                 Event::EvQueryChange => {
@@ -168,11 +171,12 @@ fn real_main() -> i32 {
                     // ignore for now
                 }
 
-                Event::EvResize => {model.resize();}
+                Event::EvResize => {model.resize(); model.display();}
 
                 Event::EvActAddChar => {
                     let ch: char = *val.downcast().unwrap();
                     model.act_add_char(ch);
+                    model.print_query();
                 }
                 // Actions
 
@@ -185,35 +189,37 @@ fn real_main() -> i32 {
                     exit_code = if num_selected > 0 {0} else {1};
                     break 'outer;
                 }
-                Event::EvActBackwardChar       => {model.act_backward_char();}
-                Event::EvActBackwardDeleteChar => {model.act_backward_delete_char();}
-                Event::EvActBackwardKillWord   => {model.act_backward_kill_word();}
-                Event::EvActBackwardWord       => {model.act_backward_word();}
-                Event::EvActBeginningOfLine    => {model.act_beginning_of_line();}
+                Event::EvActBackwardChar       => {model.act_backward_char();       model.print_query();}
+                Event::EvActBackwardDeleteChar => {model.act_backward_delete_char();model.print_query();}
+                Event::EvActBackwardKillWord   => {model.act_backward_kill_word();  model.print_query();}
+                Event::EvActBackwardWord       => {model.act_backward_word();       model.print_query();}
+                Event::EvActBeginningOfLine    => {model.act_beginning_of_line();   model.print_query();}
                 Event::EvActCancel             => {}
                 Event::EvActClearScreen        => {model.refresh();}
-                Event::EvActDeleteChar         => {model.act_delete_char();}
-                Event::EvActDeleteCharEOF      => {model.act_delete_char();}
-                Event::EvActDeselectAll        => {model.act_deselect_all();}
-                Event::EvActDown               => {model.act_move_line_cursor(-1);}
-                Event::EvActEndOfLine          => {model.act_end_of_line();}
-                Event::EvActForwardChar        => {model.act_forward_char();}
-                Event::EvActForwardWord        => {model.act_forward_word();}
+                Event::EvActDeleteChar         => {model.act_delete_char();         model.print_query();}
+                Event::EvActDeleteCharEOF      => {model.act_delete_char();         model.print_query();}
+                Event::EvActDeselectAll        => {model.act_deselect_all();        model.print_info(); model.print_items();}
+                Event::EvActDown               => {model.act_move_line_cursor(-1);  model.print_items();}
+                Event::EvActEndOfLine          => {model.act_end_of_line();         model.print_query();}
+                Event::EvActForwardChar        => {model.act_forward_char();        model.print_query();}
+                Event::EvActForwardWord        => {model.act_forward_word();        model.print_query();}
                 Event::EvActIgnore             => {}
-                Event::EvActKillLine           => {model.act_kill_line();}
-                Event::EvActKillWord           => {model.act_kill_word();}
+                Event::EvActKillLine           => {model.act_kill_line();           model.print_query();}
+                Event::EvActKillWord           => {model.act_kill_word();           model.print_query();}
                 Event::EvActNextHistory        => {}
-                Event::EvActPageDown           => {model.act_move_page(-1);}
-                Event::EvActPageUp             => {model.act_move_page(1);}
+                Event::EvActPageDown           => {model.act_move_page(-1);         model.print_items();}
+                Event::EvActPageUp             => {model.act_move_page(1);          model.print_items();}
                 Event::EvActPreviousHistory    => {}
-                Event::EvActScrollLeft         => {model.act_vertical_scroll(-1);}
-                Event::EvActScrollRight        => {model.act_vertical_scroll(1);}
-                Event::EvActSelectAll          => {model.act_select_all();}
-                Event::EvActToggle             => {model.act_toggle();}
-                Event::EvActToggleAll          => {model.act_toggle_all();}
+                Event::EvActScrollLeft         => {model.act_vertical_scroll(-1);   model.print_items();}
+                Event::EvActScrollRight        => {model.act_vertical_scroll(1);    model.print_items();}
+                Event::EvActSelectAll          => {model.act_select_all();          model.print_info(); model.print_items();}
+                Event::EvActToggle             => {model.act_toggle();              model.print_info(); model.print_items();}
+                Event::EvActToggleAll          => {model.act_toggle_all();          model.print_info(); model.print_items();}
                 Event::EvActToggleDown         => {
                     model.act_toggle();
                     model.act_move_line_cursor(-1);
+                    model.print_info();
+                    model.print_items();
                 }
                 Event::EvActToggleIn           => {}
                 Event::EvActToggleOut          => {}
@@ -221,23 +227,24 @@ fn real_main() -> i32 {
                 Event::EvActToggleUp           => {
                     model.act_toggle();
                     model.act_move_line_cursor(1);
+                    model.print_info();
+                    model.print_items();
                 }
-                Event::EvActUnixLineDiscard    => {model.act_line_discard();}
-                Event::EvActUnixWordRubout     => {model.act_backward_kill_word();}
-                Event::EvActUp                 => {model.act_move_line_cursor(1);}
+                Event::EvActUnixLineDiscard    => {model.act_line_discard();       model.print_query();}
+                Event::EvActUnixWordRubout     => {model.act_backward_kill_word(); model.print_query();}
+                Event::EvActUp                 => {model.act_move_line_cursor(1);  model.print_items();}
                 Event::EvActYank               => {}
 
                 _ => {
                     printw(format!("{}\n", e as i32).as_str());
                 }
             }
+
+            model.refresh();
+            thread::sleep(Duration::from_millis(10));
         }
 
-        thread::sleep(Duration::from_millis(10));
-        model.display();
-        if need_refresh {
-            model.refresh();
-        }
+
     };
 
     model.close();

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,10 +152,7 @@ fn real_main() -> i32 {
                 Event::EvMatcherEnd => {
                     // do nothing
                     let result: OrderedVec<MatchedItem> = *val.downcast().unwrap();
-                    {
-                        let mut matched_items = model.matched_items.borrow_mut();
-                        *matched_items = result;
-                    }
+                    model.update_matched_items(result);
                     model.display();
                 }
 
@@ -178,8 +175,8 @@ fn real_main() -> i32 {
                     model.act_add_char(ch);
                     model.print_query();
                 }
-                // Actions
 
+                // Actions
                 Event::EvActAbort => {exit_code = 130; break 'outer; }
                 Event::EvActAccept => {
                     // break out of the loop and output the selected item.
@@ -243,8 +240,6 @@ fn real_main() -> i32 {
             model.refresh();
             thread::sleep(Duration::from_millis(10));
         }
-
-
     };
 
     model.close();

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,8 +145,8 @@ fn real_main() -> i32 {
                 }
 
                 Event::EvMatcherUpdateProcess => {
-                    let (matched, total, processed) : (u64, u64, u64) = *val.downcast().unwrap();
-                    model.update_process_info(matched, total, processed);
+                    let percentage: u64 = *val.downcast().unwrap();
+                    model.update_process_info(percentage);
                 }
 
                 Event::EvMatcherEnd => {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -123,8 +123,10 @@ impl<'a> Matcher {
         }
 
         // consume remaining results.
-        while let Ok(Some(matched)) = rx.try_recv() {
-            cache.matched_items.push(matched);
+        while let Ok(result) = rx.try_recv() {
+            if let Some(matched) = result {
+                cache.matched_items.push(matched);
+            }
         }
         cache.item_pos = *start_pos.lock().unwrap();
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -40,8 +40,6 @@ pub struct Model {
     eb: Arc<EventBox<Event>>,
     pub query: Query,
 
-    num_matched: u64,
-    num_total: u64,
     pub items: Arc<RwLock<Vec<Item>>>, // all items
     selected_indics: HashSet<usize>,
     pub matched_items: RefCell<OrderedVec<MatchedItem>>,
@@ -74,8 +72,6 @@ impl Model {
         Model {
             eb: eb,
             query: Query::new(),
-            num_matched: 0,
-            num_total: 0,
             items: Arc::new(RwLock::new(Vec::new())),
             selected_indics: HashSet::new(),
             matched_items: RefCell::new(OrderedVec::new()),
@@ -108,10 +104,8 @@ impl Model {
         }
     }
 
-    pub fn update_process_info(&mut self, matched: u64, total: u64, processed: u64) {
-        self.num_matched = matched;
-        self.num_total = total;
-        self.processed_percentage = (processed+1)*100/(total+1);
+    pub fn update_process_info(&mut self, percentage: u64) {
+        self.processed_percentage = percentage;
     }
 
     pub fn clear_items(&mut self) {
@@ -140,7 +134,10 @@ impl Model {
             self.print_char(' ', COLOR_NORMAL, false);
         }
 
-        self.curses.cprint(format!(" {}/{}", self.num_matched, self.num_total).as_ref(), COLOR_INFO, false);
+        let num_matched = self.matched_items.borrow().len();
+        let num_total = self.items.read().unwrap().len();
+
+        self.curses.cprint(format!(" {}/{}", num_matched, num_total).as_ref(), COLOR_INFO, false);
 
         if self.multi_selection && self.selected_indics.len() > 0 {
             self.curses.cprint(format!(" [{}]", self.selected_indics.len()).as_ref(), COLOR_INFO, true);

--- a/src/model.rs
+++ b/src/model.rs
@@ -114,6 +114,16 @@ impl Model {
         self.percentage = percentage;
     }
 
+    pub fn update_matched_items(&mut self, items: OrderedVec<MatchedItem>) {
+        let mut matched_items = self.matched_items.borrow_mut();
+        *matched_items = items;
+
+        // update cursor
+        let item_len = matched_items.len();
+        self.item_cursor = min(self.item_cursor, if item_len > 0 {item_len-1} else {0});
+        self.line_cursor = min(self.line_cursor, self.item_cursor);
+    }
+
     pub fn clear_items(&mut self) {
         self.matched_items.borrow_mut().clear();
         self.item_cursor = 0;

--- a/src/model.rs
+++ b/src/model.rs
@@ -114,10 +114,6 @@ impl Model {
         self.processed_percentage = (processed+1)*100/(total+1);
     }
 
-    pub fn push_item(&mut self, item: MatchedItem) {
-        self.matched_items.borrow_mut().push(item);
-    }
-
     pub fn clear_items(&mut self) {
         self.matched_items.borrow_mut().clear();
         self.item_cursor = 0;

--- a/src/orderedvec.rs
+++ b/src/orderedvec.rs
@@ -1,63 +1,76 @@
 // ordered container
+// Normally, user will only care about the first several options. So we only keep several of them
+// in order. Other items are kept unordered and are sorted on demand.
 
-use std::collections::BinaryHeap;
+const ORDERED_SIZE: usize = 300;
 
 #[derive(Clone)]
 pub struct OrderedVec<T: Ord> {
-    heap: BinaryHeap<T>,
-    vec: Vec<T>,
+    ordered: Vec<T>,
+    unordered: Vec<T>,
     sorted: bool,
-    index_min: usize,
 }
 
 impl<T> OrderedVec<T> where T: Ord {
     pub fn new() -> Self {
         OrderedVec {
-            heap: BinaryHeap::new(),
-            vec: Vec::new(),
-            sorted: true,
-            index_min: 0,
+            ordered: Vec::new(),
+            unordered: Vec::new(),
+            sorted: false,
+        }
+    }
+
+    fn ordered_insert(&mut self, item: T) {
+        self.ordered.push(item);
+        let mut pos = self.ordered.len() - 1;
+        while pos > 0 && self.ordered[pos] > self.ordered[pos-1] {
+            self.ordered.swap(pos, pos-1);
+            pos -= 1;
         }
     }
 
     pub fn push(&mut self, item: T) {
-        if self.index_min > 0 && item > self.vec[self.index_min/2] {
-            self.vec.push(item);
-            self.sorted = false;
+        if self.ordered.len() < ORDERED_SIZE {
+            self.ordered_insert(item);
+            return;
+        } 
+
+        let smaller = if item < *self.ordered.last().unwrap() {
+            item
         } else {
-            self.heap.push(item);
-        }
+            self.ordered_insert(item);
+            self.ordered.pop().unwrap()
+        };
+
+        self.unordered.push(smaller);
+        self.sorted = false;
     }
 
     pub fn get(&mut self, index: usize) -> Option<&T> {
-        if !self.sorted {
-            self.vec.sort_by(|a, b| b.cmp(a));
+        if index < self.ordered.len() {
+            return self.ordered.get(index);
         }
 
-        if index >= self.vec.len() + self.heap.len() {
+        if index >= self.ordered.len() + self.unordered.len() {
             return None;
         }
 
-        let mut len = self.vec.len();
-        while len <= index {
-            self.vec.push(self.heap.pop().unwrap());
-            len += 1;
+        if !self.sorted {
+            self.unordered.sort_by(|a, b| b.cmp(a));
+            self.sorted = true;
         }
 
-        self.sorted = true;
-        self.index_min = self.vec.len();
-        return self.vec.get(index);
+        return self.unordered.get(index - self.ordered.len());
     }
 
     pub fn len(&self) -> usize {
-        return self.vec.len() + self.heap.len();
+        return self.ordered.len() + self.unordered.len();
     }
 
     pub fn clear(&mut self) {
-        self.vec.clear();
-        self.heap.clear();
+        self.ordered.clear();
+        self.unordered.clear();
         self.sorted = true;
-        self.index_min = 0;
     }
 }
 

--- a/src/orderedvec.rs
+++ b/src/orderedvec.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BinaryHeap;
 
+#[derive(Clone)]
 pub struct OrderedVec<T: Ord> {
     heap: BinaryHeap<T>,
     vec: Vec<T>,

--- a/src/orderedvec.rs
+++ b/src/orderedvec.rs
@@ -21,7 +21,7 @@ impl<T> OrderedVec<T> where T: Ord {
     }
 
     pub fn push(&mut self, item: T) {
-        if self.index_min > 0 && item >= self.vec[self.index_min-1] {
+        if self.index_min > 0 && item > self.vec[self.index_min/2] {
             self.vec.push(item);
             self.sorted = false;
         } else {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -11,6 +11,8 @@ use util::eventbox::EventBox;
 use event::Event;
 use item::Item;
 
+const READER_EVENT_DURATION: u64 = 30;
+
 pub struct Reader {
     cmd: String, // command to invoke
     eb: Arc<EventBox<Event>>,         // eventbox
@@ -63,9 +65,10 @@ impl Reader {
                 }
                 Err(_err) => { break; }
             }
-            self.eb.set(Event::EvReaderNewItem, Box::new(true));
+
+            self.eb.set_throttle(Event::EvReaderNewItem, Box::new(true), READER_EVENT_DURATION);
         }
-        self.eb.set(Event::EvReaderNewItem, Box::new(false));
+        self.eb.set_throttle(Event::EvReaderNewItem, Box::new(false), READER_EVENT_DURATION);
     }
 }
 

--- a/src/util/eventbox.rs
+++ b/src/util/eventbox.rs
@@ -13,7 +13,7 @@
 /// ```
 /// use std::sync::Arc;
 /// use std::thread;
-/// use fzf_rs::util::eventbox::EventBox;
+/// use skim::util::eventbox::EventBox;
 /// let mut eb = Arc::new(EventBox::new());
 /// let mut eb2 = eb.clone();
 ///
@@ -25,30 +25,37 @@
 /// assert_eq!(20, val);
 /// ```
 
-use std::sync::{Condvar, Mutex};
-use std::collections::HashMap;
+use std::sync::{Condvar, Mutex, Arc};
+use std::collections::{HashMap, HashSet};
 use std::any::Any;
 use std::mem;
 use std::hash::Hash;
+use std::thread;
+use std::time::Duration;
 
 pub type Value = Box<Any + 'static + Send>;
 pub type Events<T> = HashMap<T, Value>;
 
 struct EventData<T> {
-    events: Events<T>,
-    ignore: Events<T>,
+    events:    Events<T>,
+    lazy:      HashSet<T>,
+    blocked:   HashSet<T>,
+    throttled: Events<T>,
 }
 
 pub struct EventBox<T> {
-    mutex: Mutex<EventData<T>>,
-    cond: Condvar,
+    mutex: Arc<Mutex<EventData<T>>>,
+    cond: Arc<Condvar>,
 }
 
-impl<T: Hash + Eq + Copy> EventBox<T> {
+impl<T> EventBox<T> where T: Hash + Eq + Copy + 'static + Send {
     pub fn new() -> Self {
         EventBox {
-            mutex: Mutex::new(EventData{events: HashMap::new(), ignore: HashMap::new()}),
-            cond: Condvar::new(),
+            mutex: Arc::new(Mutex::new(EventData{events:    HashMap::new(),
+                                                 lazy:      HashSet::new(),
+                                                 throttled: HashMap::new(),
+                                                 blocked:   HashSet::new()})),
+            cond: Arc::new(Condvar::new()),
         }
     }
 
@@ -69,15 +76,17 @@ impl<T: Hash + Eq + Copy> EventBox<T> {
 
     /// set: fires an event
     pub fn set(&self, e: T, value: Value) {
-        let mut data = self.mutex.lock().unwrap();
-        {
-            let val = data.events.entry(e).or_insert(Box::new(0));
-            *val = value;
-        }
-        if !data.ignore.contains_key(&e) {
-            self.cond.notify_all();
-        }
+        set_event(&self.mutex, &self.cond, e, value)
     }
+
+    /// set_throttle: limit the number of an event within a timeout.
+    ///  X X XX XY Y YY Y
+    /// |        |        |
+    ///  X        X        Y
+    pub fn set_throttle(&self, e: T, value: Value, timeout: u64) {
+        set_event_throttle(&self.mutex, &self.cond, e, value, timeout, false);
+    }
+
 
     /// clear the event map
     pub fn clear(&self) {
@@ -91,19 +100,19 @@ impl<T: Hash + Eq + Copy> EventBox<T> {
         data.events.contains_key(&event)
     }
 
-    // remove events from ignore table
+    // remove events from lazy table
     pub fn watch(&self, events: &Vec<T>) {
         let mut data = self.mutex.lock().unwrap();
         for e in events {
-            data.ignore.remove(e);
+            data.lazy.remove(e);
         }
     }
 
-    // add events from ignore table
+    // add events from lazy table
     pub fn unwatch(&self, events: &Vec<T>) {
         let mut data = self.mutex.lock().unwrap();
         for e in events {
-            data.ignore.insert(*e, Box::new(true));
+            data.lazy.insert(*e);
         }
     }
 
@@ -123,12 +132,62 @@ impl<T: Hash + Eq + Copy> EventBox<T> {
     }
 }
 
+
+fn set_event<T>(mutex: &Arc<Mutex<EventData<T>>>, cond: &Arc<Condvar>, e: T, value: Value)
+    where T: Hash + Eq + Copy + 'static + Send {
+    let mut data = mutex.lock().unwrap();
+    {
+
+        let val = data.events.entry(e).or_insert(Box::new(0));
+        *val = value;
+    }
+
+    if !data.lazy.contains(&e) {
+        cond.notify_all();
+    }
+}
+
+fn set_event_throttle<T>(mutex: &Arc<Mutex<EventData<T>>>, cond: &Arc<Condvar>, e: T, value: Value, timeout: u64, from_thread: bool)
+    where T: Hash + Eq + Copy + 'static + Send {
+    {
+        let mut data = mutex.lock().unwrap();
+        if !from_thread && data.blocked.contains(&e) {
+            let val = data.throttled.entry(e).or_insert(Box::new(0));
+            *val = value;
+            return;
+        } else {
+            data.blocked.insert(e);
+        }
+    }
+
+    set_event(&mutex, &cond, e, value);
+
+    let mutex = mutex.clone();
+    let cond = cond.clone();
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(timeout));
+        let mut remaining = {
+            let mut data = mutex.lock().unwrap();
+            data.throttled.remove(&e)
+        };
+
+        remaining.map_or_else(
+            || {
+                let mut data = mutex.lock().unwrap();
+                let _ = data.blocked.remove(&e);
+            },
+            |v| {
+                set_event_throttle(&mutex, &cond, e, v, timeout, true);
+            });
+    });
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use std::thread;
     use std::sync::{Arc, Mutex};
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn test_wait() {
@@ -186,7 +245,7 @@ mod test {
         const NUM_OF_EVENTS: i32 = 4;
         let eb = Arc::new(EventBox::new());
 
-        // this time, we ignore event NO. NUM_OF_EVENTS
+        // this time, we lazy event NO. NUM_OF_EVENTS
         // note that unwatch will not trigger the event notification, but the
         // value are actually set.
         eb.unwatch(&vec![NUM_OF_EVENTS]);
@@ -253,4 +312,43 @@ mod test {
 
         wait.join();
     }
+
+    // Not including this test, because we should not rely on eventbox to do the dispatching at
+    // exact time. In this sense, it is better not to include this in the test suite.
+    //
+    //#[test]
+    //fn test_set_throttle() {
+        //let eb = Arc::new(EventBox::new());
+
+        //let eb_clone = eb.clone();
+        //thread::spawn(move || {
+            //// will receive: 0, 2, 5, 7
+            //for i in 0..10 {
+                //eb_clone.set_throttle(1, Box::new(i), 20);
+                //thread::sleep(Duration::from_millis(7));
+            //}
+        //});
+
+        //let mut total: i32 = 0;
+        //let timer = Instant::now();
+        //loop {
+
+            //if eb.peek(1) {
+                //for (_, val) in eb.wait() {
+                    //let x = *val.downcast().unwrap();
+                    //println!("x = {}", x);
+                    //total += x;
+                //}
+            //}
+
+            //let time = timer.elapsed();
+            //let mills = (time.as_secs()*1000) as u32 + time.subsec_nanos()/1000/1000;
+            //if mills > 100 {
+                //break;
+            //}
+        //}
+
+        //assert_eq!(total, 24);
+    //}
+
 }

--- a/src/util/eventbox.rs
+++ b/src/util/eventbox.rs
@@ -60,8 +60,11 @@ impl<T: Hash + Eq + Copy> EventBox<T> {
         let num_of_events = events.len();
         if num_of_events == 0 {
             let _ = self.cond.wait(data);
+            let mut data = self.mutex.lock().unwrap();
+            mem::replace(&mut data.events, HashMap::new())
+        } else {
+            events
         }
-        events
     }
 
     /// set: fires an event

--- a/src/util/eventbox.rs
+++ b/src/util/eventbox.rs
@@ -166,7 +166,7 @@ fn set_event_throttle<T>(mutex: &Arc<Mutex<EventData<T>>>, cond: &Arc<Condvar>, 
     let cond = cond.clone();
     thread::spawn(move || {
         thread::sleep(Duration::from_millis(timeout));
-        let mut remaining = {
+        let remaining = {
             let mut data = mutex.lock().unwrap();
             data.throttled.remove(&e)
         };


### PR DESCRIPTION
The major reason of screen flicker caused by the design: skim tempt to be async on matching. That means the screen will be updated as soon as a new matched items came.

So in order to enhance user experience, I've tried several ways:
1. Only update the screen after all matching is done.
2. Update the screen part by part. For example when matching, the info area is updated but not item area.
3. Use a more stable data structure for storing matched items.
4. limit the event rate.