### PR TITLE
Speed Improvement

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -5,13 +5,20 @@ use std::cmp::Ordering;
 
 pub struct Item {
     pub text: String,
+    text_lower_chars: Vec<char>, // lower case version of text.
 }
 
 impl Item {
     pub fn new(text: String) -> Self {
+        let lower_chars = text.to_lowercase().chars().collect();
         Item {
             text: text,
+            text_lower_chars: lower_chars,
         }
+    }
+
+    pub fn get_lower_chars(&self) -> &[char] {
+        &self.text_lower_chars
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,10 @@ fn real_main() -> i32 {
                     // ignore for now
                 }
 
-                Event::EvResize => {model.resize(); model.display();}
+                Event::EvResize => {
+                    model.resize();
+                    model.display();
+                }
 
                 Event::EvActAddChar => {
                     let ch: char = *val.downcast().unwrap();
@@ -177,7 +180,11 @@ fn real_main() -> i32 {
                 }
 
                 // Actions
-                Event::EvActAbort => {exit_code = 130; break 'outer; }
+                Event::EvActAbort => {
+                    exit_code = 130;
+                    break 'outer;
+                }
+
                 Event::EvActAccept => {
                     // break out of the loop and output the selected item.
                     //if model.get_num_selected() <= 0 { model.act_toggle(Some(true)); }
@@ -186,60 +193,172 @@ fn real_main() -> i32 {
                     exit_code = if num_selected > 0 {0} else {1};
                     break 'outer;
                 }
-                Event::EvActBackwardChar       => {model.act_backward_char();       model.print_query();}
-                Event::EvActBackwardDeleteChar => {model.act_backward_delete_char();model.print_query();}
-                Event::EvActBackwardKillWord   => {model.act_backward_kill_word();  model.print_query();}
-                Event::EvActBackwardWord       => {model.act_backward_word();       model.print_query();}
-                Event::EvActBeginningOfLine    => {model.act_beginning_of_line();   model.print_query();}
-                Event::EvActCancel             => {}
-                Event::EvActClearScreen        => {model.refresh();}
-                Event::EvActDeleteChar         => {model.act_delete_char();         model.print_query();}
-                Event::EvActDeleteCharEOF      => {model.act_delete_char();         model.print_query();}
-                Event::EvActDeselectAll        => {model.act_deselect_all();        model.print_info(); model.print_items();}
-                Event::EvActDown               => {model.act_move_line_cursor(-1);  model.print_items();}
-                Event::EvActEndOfLine          => {model.act_end_of_line();         model.print_query();}
-                Event::EvActForwardChar        => {model.act_forward_char();        model.print_query();}
-                Event::EvActForwardWord        => {model.act_forward_word();        model.print_query();}
-                Event::EvActIgnore             => {}
-                Event::EvActKillLine           => {model.act_kill_line();           model.print_query();}
-                Event::EvActKillWord           => {model.act_kill_word();           model.print_query();}
-                Event::EvActNextHistory        => {}
-                Event::EvActPageDown           => {model.act_move_page(-1);         model.print_items();}
-                Event::EvActPageUp             => {model.act_move_page(1);          model.print_items();}
-                Event::EvActPreviousHistory    => {}
-                Event::EvActScrollLeft         => {model.act_vertical_scroll(-1);   model.print_items();}
-                Event::EvActScrollRight        => {model.act_vertical_scroll(1);    model.print_items();}
-                Event::EvActSelectAll          => {model.act_select_all();          model.print_info(); model.print_items();}
-                Event::EvActToggle             => {model.act_toggle();              model.print_info(); model.print_items();}
-                Event::EvActToggleAll          => {model.act_toggle_all();          model.print_info(); model.print_items();}
-                Event::EvActToggleDown         => {
+
+                Event::EvActBackwardChar => {
+                    model.act_backward_char();
+                    model.print_query();
+                }
+
+                Event::EvActBackwardDeleteChar => {
+                    model.act_backward_delete_char();
+                    model.print_query();
+                }
+
+                Event::EvActBackwardKillWord => {
+                    model.act_backward_kill_word();
+                    model.print_query();
+                }
+
+                Event::EvActBackwardWord => {
+                    model.act_backward_word();
+                    model.print_query();
+                }
+
+                Event::EvActBeginningOfLine => {
+                    model.act_beginning_of_line();
+                    model.print_query();
+                }
+
+                Event::EvActCancel => {}
+
+                Event::EvActClearScreen => {
+                    model.refresh();
+                }
+
+                Event::EvActDeleteChar => {
+                    model.act_delete_char();
+                    model.print_query();
+                }
+
+                Event::EvActDeleteCharEOF => {
+                    model.act_delete_char();
+                    model.print_query();
+                }
+
+                Event::EvActDeselectAll => {
+                    model.act_deselect_all();
+                    model.print_info();
+                    model.print_items();
+                }
+
+                Event::EvActDown => {
+                    model.act_move_line_cursor(-1);
+                    model.print_items();
+                }
+
+                Event::EvActEndOfLine => {
+                    model.act_end_of_line();
+                    model.print_query();
+                }
+
+                Event::EvActForwardChar => {
+                    model.act_forward_char();
+                    model.print_query();
+                }
+
+                Event::EvActForwardWord => {
+                    model.act_forward_word();
+                    model.print_query();
+                }
+
+                Event::EvActIgnore => {}
+
+                Event::EvActKillLine => {
+                    model.act_kill_line();
+                    model.print_query();
+                }
+
+                Event::EvActKillWord => {
+                    model.act_kill_word();
+                    model.print_query();
+                }
+
+                Event::EvActNextHistory => {}
+
+                Event::EvActPageDown => {
+                    model.act_move_page(-1);
+                    model.print_items();
+                }
+
+                Event::EvActPageUp => {
+                    model.act_move_page(1);
+                    model.print_items();
+                }
+
+                Event::EvActPreviousHistory => {}
+
+                Event::EvActScrollLeft => {
+                    model.act_vertical_scroll(-1);
+                    model.print_items();
+                }
+
+                Event::EvActScrollRight => {
+                    model.act_vertical_scroll(1);
+                    model.print_items();
+                }
+
+                Event::EvActSelectAll => {
+                    model.act_select_all();
+                    model.print_info();
+                    model.print_items();
+                }
+
+                Event::EvActToggle => {
+                    model.act_toggle();
+                    model.print_info();
+                    model.print_items();
+                }
+
+                Event::EvActToggleAll => {
+                    model.act_toggle_all();
+                    model.print_info();
+                    model.print_items();
+                }
+
+                Event::EvActToggleDown => {
                     model.act_toggle();
                     model.act_move_line_cursor(-1);
                     model.print_info();
                     model.print_items();
                 }
-                Event::EvActToggleIn           => {}
-                Event::EvActToggleOut          => {}
-                Event::EvActToggleSort         => {}
-                Event::EvActToggleUp           => {
+
+                Event::EvActToggleIn => {}
+
+                Event::EvActToggleOut => {}
+
+                Event::EvActToggleSort => {}
+
+                Event::EvActToggleUp => {
                     model.act_toggle();
                     model.act_move_line_cursor(1);
                     model.print_info();
                     model.print_items();
                 }
-                Event::EvActUnixLineDiscard    => {model.act_line_discard();       model.print_query();}
-                Event::EvActUnixWordRubout     => {model.act_backward_kill_word(); model.print_query();}
-                Event::EvActUp                 => {model.act_move_line_cursor(1);  model.print_items();}
-                Event::EvActYank               => {}
+
+                Event::EvActUnixLineDiscard => {
+                    model.act_line_discard();
+                    model.print_query();
+                }
+
+                Event::EvActUnixWordRubout => {
+                    model.act_backward_kill_word();
+                    model.print_query();
+                }
+
+                Event::EvActUp => {
+                    model.act_move_line_cursor(1);
+                    model.print_items();
+                }
+
+                Event::EvActYank => {}
 
                 _ => {
                     printw(format!("{}\n", e as i32).as_str());
                 }
             }
-
-            model.refresh();
-            thread::sleep(Duration::from_millis(10));
         }
+        model.refresh();
+        thread::sleep(Duration::from_millis(10));
     };
 
     model.close();

--- a/src/model.rs
+++ b/src/model.rs
@@ -263,7 +263,6 @@ impl Model {
     }
 
     pub fn display(&self) {
-        erase();
         self.print_items();
         self.print_info();
         self.print_query();

--- a/src/score.rs
+++ b/src/score.rs
@@ -15,7 +15,7 @@ const PENALTY_MAX_LEADING: i64 = -18; // maxing penalty for leading letters
 const PENALTY_UNMATCHED: i64 = -2;
 
 // judge how many scores the current index should get
-fn fuzzy_score(string: &Vec<char>, index: usize, pattern: &Vec<char>, pattern_idx: usize) -> i64 {
+fn fuzzy_score(string: &[char], index: usize, pattern: &[char], pattern_idx: usize) -> i64 {
     let mut score = 0;
 
     let pattern_char = pattern[pattern_idx];
@@ -50,28 +50,23 @@ fn fuzzy_score(string: &Vec<char>, index: usize, pattern: &Vec<char>, pattern_id
     score
 }
 
-pub fn fuzzy_match(choice: &str, pattern: &str) -> Option<(i64, Vec<usize>)>{
+pub fn fuzzy_match(choice: &[char], pattern: &[char], pattern_lower: &[char]) -> Option<(i64, Vec<usize>)>{
     if pattern.len() == 0 {
         return Some((0, Vec::new()));
     }
-
-    let choice_chars: Vec<char> = choice.chars().collect();
-    let choice_lower = choice.to_lowercase();
-    let pattern_chars: Vec<char> = pattern.chars().collect();
-    let pattern_chars_lower: Vec<char> = pattern.to_lowercase().chars().collect();
 
     let mut scores = vec![];
     let mut picked = vec![];
 
     let mut prev_matched_idx = -1; // to ensure that the pushed char are able to match the pattern
-    for pattern_idx in 0..pattern_chars_lower.len() {
-        let pattern_char = pattern_chars_lower[pattern_idx];
+    for pattern_idx in 0..pattern_lower.len() {
+        let pattern_char = pattern_lower[pattern_idx];
         let vec_cell = RefCell::new(vec![]);
         {
             let mut vec = vec_cell.borrow_mut();
-            for (idx, ch) in choice_lower.chars().enumerate() {
+            for (idx, &ch) in choice.iter().enumerate() {
                 if ch == pattern_char && (idx as i64) > prev_matched_idx {
-                    vec.push((idx, fuzzy_score(&choice_chars, idx, &pattern_chars, pattern_idx), 0)); // (char_idx, score, vec_idx back_ref)
+                    vec.push((idx, fuzzy_score(choice, idx, pattern, pattern_idx), 0)); // (char_idx, score, vec_idx back_ref)
                 }
             }
 

--- a/src/score.rs
+++ b/src/score.rs
@@ -50,7 +50,9 @@ fn fuzzy_score(string: &[char], index: usize, pattern: &[char], pattern_idx: usi
     score
 }
 
-pub fn fuzzy_match(choice: &[char], pattern: &[char], pattern_lower: &[char]) -> Option<(i64, Vec<usize>)>{
+pub fn fuzzy_match(choice: &[char],
+                   pattern: &[char],
+                   pattern_lower: &[char]) -> Option<(i64, Vec<usize>)>{
     if pattern.len() == 0 {
         return Some((0, Vec::new()));
     }


### PR DESCRIPTION
Previously the call to `to_lowercase` is the bottleneck of the speed, around 50% of the time. Now we cached the lower case characters so that we don't need to call it in every match.

After the cache, the speed improves a lot. However the profiling shows that still about 30% of the time is occupied by `to_lowercase`. The other is cloning the matched_items from matcher's cache(around 30%). Which I don't know how to avoid for now.