### PR TITLE
[speed] share matched_items between matcher and model

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ fn real_main() -> i32 {
 
                 Event::EvMatcherEnd => {
                     // do nothing
-                    let result: OrderedVec<MatchedItem> = *val.downcast().unwrap();
+                    let result: Arc<RwLock<OrderedVec<MatchedItem>>> = *val.downcast().unwrap();
                     model.update_matched_items(result);
                     model.display();
                 }


### PR DESCRIPTION
Before: we will cache the result of a search for later use, this will cause us
to clone the result even it is the first time to search. If the matched item
number is large(short query) then the clone time is large(30%).

After: we share the matched result so this clone time should be reduced.

Rust did not support sharing reference between threads to keep thread safety.
Thus we use Arc<RwLock<_>> to wrap up the data and send the Arc through
eventbox. The Cons of this method I think is making fields dirty(look ugly).