### PR TITLE
Feature: fields

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -74,6 +74,19 @@ impl Item {
     pub fn get_ansi_states(&self) -> &Vec<(usize, attr_t)> {
         &self.ansi_states
     }
+
+    pub fn in_matching_range(&self, begin: usize, end: usize) -> bool {
+        if self.matching_ranges.len() <= 0 {
+            return true;
+        }
+
+        for &(start, stop) in self.matching_ranges.iter() {
+            if begin >= start && end <= stop {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 fn parse_transform_fields(delimiter: &Regex, text: &str, fields: &[FieldRange]) -> String {
@@ -140,7 +153,7 @@ fn parse_field_range(range: &FieldRange, length: usize) -> Option<(usize, usize)
         FieldRange::Both(left, right) => {
             let left = if left >= 0 {left} else {length + left};
             let right = if right >= 0 {right} else {length + right};
-            if left >= right {
+            if left >= right || left >= length || right < 0 {
                 None
             } else {
                 Some((if left < 0 {0} else {left as usize},
@@ -254,6 +267,8 @@ mod test {
         assert_eq!(super::parse_field_range(&Both(-9, 1), 10), None);
         assert_eq!(super::parse_field_range(&Both(-9, 2), 10), Some((1,2)));
         assert_eq!(super::parse_field_range(&Both(-1,0), 10), None);
+        assert_eq!(super::parse_field_range(&Both(11,20), 10), None);
+        assert_eq!(super::parse_field_range(&Both(-10,-10), 10), None);
     }
 
     #[test]

--- a/src/item.rs
+++ b/src/item.rs
@@ -4,31 +4,67 @@
 use std::cmp::Ordering;
 use ncurses::*;
 use ansi::parse_ansi;
+use regex::Regex;
+use reader::FieldRange;
 
 pub struct Item {
+    orig_text: String,
     pub text: String,
     text_lower_chars: Vec<char>, // lower case version of text.
     ansi_states: Vec<(usize, attr_t)>,
+    using_transform_fields: bool,
+    matching_ranges: Vec<(usize, usize)>,
 }
 
 impl Item {
-    pub fn new(text: String, use_ansi: bool) -> Self {
-        let (text, states) = if use_ansi {
+    pub fn new(text: String,
+               use_ansi: bool,
+               trans_fields: &[FieldRange],
+               matching_fields: &[FieldRange],
+               delimiter: &Regex) -> Self {
+
+        let (orig_text, states) = if use_ansi {
              parse_ansi(&text)
         } else {
             (text, Vec::new())
         };
 
-        let lower_chars = text.to_lowercase().chars().collect();
-        Item {
+        let text = if trans_fields.len() > 0 {
+            parse_transform_fields(delimiter, &orig_text, trans_fields)
+        } else {
+            String::new()
+        };
+
+        let mut ret = Item {
+            orig_text: orig_text,
             text: text,
-            text_lower_chars: lower_chars,
+            text_lower_chars: Vec::new(),
             ansi_states: states,
-        }
+            using_transform_fields: trans_fields.len() > 0,
+            matching_ranges: Vec::new(),
+        };
+
+        let lower_chars = ret.get_text().to_lowercase().chars().collect();
+        let matching_ranges = if matching_fields.len() > 0 {
+            parse_matching_fields(delimiter, &ret.get_text(), matching_fields)
+        } else {
+            Vec::new()
+        };
+        ret.text_lower_chars = lower_chars;
+        ret.matching_ranges = matching_ranges;
+        ret
     }
 
     pub fn get_text(&self) -> &str {
-        &self.text
+        if self.using_transform_fields {
+            &self.text
+        } else {
+            &self.orig_text
+        }
+    }
+
+    pub fn get_orig_text(&self) -> &str {
+        &self.orig_text
     }
 
     pub fn get_lower_chars(&self) -> &[char] {
@@ -39,6 +75,82 @@ impl Item {
         &self.ansi_states
     }
 }
+
+fn parse_transform_fields(delimiter: &Regex, text: &str, fields: &[FieldRange]) -> String {
+    let mut ranges =  delimiter.find_iter(text).collect::<Vec<(usize, usize)>>();
+    let &(_, end) = ranges.last().unwrap_or(&(0, 0));
+    ranges.push((end, text.len()));
+
+    let mut ret = String::new();
+    for field in fields {
+        if let Some((start, stop)) = parse_field_range(field, ranges.len()) {
+            let &(begin, _) = ranges.get(start).unwrap();
+            let &(end, _) = ranges.get(stop).unwrap_or(&(text.len(), 0));
+            ret.push_str(&text[begin..end]);
+        }
+    }
+    ret
+}
+
+fn parse_matching_fields(delimiter: &Regex, text: &str, fields: &[FieldRange]) -> Vec<(usize, usize)> {
+    let mut ranges =  delimiter.find_iter(text).collect::<Vec<(usize, usize)>>();
+    let &(_, end) = ranges.last().unwrap_or(&(0, 0));
+    ranges.push((end, text.len()));
+
+    let mut ret = Vec::new();
+    for field in fields {
+        if let Some((start, stop)) = parse_field_range(field, ranges.len()) {
+            let &(begin, _) = ranges.get(start).unwrap();
+            let &(end, _) = ranges.get(stop).unwrap_or(&(text.len(), 0));
+            let first = (&text[..begin]).chars().count();
+            let last = first + (&text[begin..end]).chars().count();
+            ret.push((first, last));
+        }
+    }
+    ret
+}
+
+fn parse_field_range(range: &FieldRange, length: usize) -> Option<(usize, usize)> {
+    let length = length as i64;
+    match *range {
+        FieldRange::Single(index) => {
+            let index = if index >= 0 {index} else {length + index};
+            if index < 0 || index >= length {
+                None
+            } else {
+                Some((index as usize, (index + 1) as usize))
+            }
+        }
+        FieldRange::LeftInf(right) => {
+            let right = if right >= 0 {right} else {length + right};
+            if right <= 0 {
+                None
+            } else {
+                Some((0, if right > length {length as usize} else {right as usize}))
+            }
+        }
+        FieldRange::RightInf(left) => {
+            let left = if left >= 0 {left} else {length as i64 + left};
+            if left >= length {
+                None
+            } else {
+                Some((if left < 0 {0} else {left} as usize, length as usize))
+            }
+        }
+        FieldRange::Both(left, right) => {
+            let left = if left >= 0 {left} else {length + left};
+            let right = if right >= 0 {right} else {length + right};
+            if left >= right {
+                None
+            } else {
+                Some((if left < 0 {0} else {left as usize},
+                      if right > length {length as usize} else {right as usize}))
+            }
+        }
+    }
+}
+
+
 
 pub type Rank = [i64; 4]; // score, index, start, end
 
@@ -90,5 +202,123 @@ impl PartialOrd for MatchedItem {
 impl PartialEq for MatchedItem {
     fn eq(&self, other: &MatchedItem) -> bool {
         self.rank == other.rank
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use reader::FieldRange::*;
+    use regex::Regex;
+
+    #[test]
+    fn test_parse_field_range() {
+        assert_eq!(super::parse_field_range(&Single(0), 10), Some((0,1)));
+        assert_eq!(super::parse_field_range(&Single(9), 10), Some((9,10)));
+        assert_eq!(super::parse_field_range(&Single(10), 10), None);
+        assert_eq!(super::parse_field_range(&Single(-1), 10), Some((9,10)));
+        assert_eq!(super::parse_field_range(&Single(-10), 10), Some((0,1)));
+        assert_eq!(super::parse_field_range(&Single(-11), 10), None);
+
+        assert_eq!(super::parse_field_range(&LeftInf(0), 10), None);
+        assert_eq!(super::parse_field_range(&LeftInf(1), 10), Some((0,1)));
+        assert_eq!(super::parse_field_range(&LeftInf(8), 10), Some((0,8)));
+        assert_eq!(super::parse_field_range(&LeftInf(10), 10), Some((0,10)));
+        assert_eq!(super::parse_field_range(&LeftInf(11), 10), Some((0,10)));
+        assert_eq!(super::parse_field_range(&LeftInf(-1), 10), Some((0,9)));
+        assert_eq!(super::parse_field_range(&LeftInf(-8), 10), Some((0,2)));
+        assert_eq!(super::parse_field_range(&LeftInf(-9), 10), Some((0,1)));
+        assert_eq!(super::parse_field_range(&LeftInf(-10), 10), None);
+        assert_eq!(super::parse_field_range(&LeftInf(-11), 10), None);
+
+        assert_eq!(super::parse_field_range(&RightInf(0), 10), Some((0,10)));
+        assert_eq!(super::parse_field_range(&RightInf(1), 10), Some((1,10)));
+        assert_eq!(super::parse_field_range(&RightInf(8), 10), Some((8,10)));
+        assert_eq!(super::parse_field_range(&RightInf(10), 10), None);
+        assert_eq!(super::parse_field_range(&RightInf(11), 10), None);
+        assert_eq!(super::parse_field_range(&RightInf(-1), 10), Some((9,10)));
+        assert_eq!(super::parse_field_range(&RightInf(-8), 10), Some((2,10)));
+        assert_eq!(super::parse_field_range(&RightInf(-9), 10), Some((1,10)));
+        assert_eq!(super::parse_field_range(&RightInf(-10), 10), Some((0, 10)));
+        assert_eq!(super::parse_field_range(&RightInf(-11), 10), Some((0, 10)));
+
+        assert_eq!(super::parse_field_range(&Both(0,0), 10), None);
+        assert_eq!(super::parse_field_range(&Both(0,1), 10), Some((0,1)));
+        assert_eq!(super::parse_field_range(&Both(0,10), 10), Some((0,10)));
+        assert_eq!(super::parse_field_range(&Both(0,11), 10), Some((0, 10)));
+        assert_eq!(super::parse_field_range(&Both(1,-1), 10), Some((1, 9)));
+        assert_eq!(super::parse_field_range(&Both(1,-9), 10), None);
+        assert_eq!(super::parse_field_range(&Both(1,-10), 10), None);
+        assert_eq!(super::parse_field_range(&Both(-9,-9), 10), None);
+        assert_eq!(super::parse_field_range(&Both(-9,-8), 10), Some((1, 2)));
+        assert_eq!(super::parse_field_range(&Both(-9, 0), 10), None);
+        assert_eq!(super::parse_field_range(&Both(-9, 1), 10), None);
+        assert_eq!(super::parse_field_range(&Both(-9, 2), 10), Some((1,2)));
+        assert_eq!(super::parse_field_range(&Both(-1,0), 10), None);
+    }
+
+    #[test]
+    fn test_parse_transform_fields() {
+        // delimiter is ","
+        let re = Regex::new(".*?,").unwrap();
+
+        assert_eq!(super::parse_transform_fields(&re, &"A,B,C,D,E,F",
+                                                 &vec![Single(1),
+                                                       Single(3),
+                                                       Single(-1),
+                                                       Single(-7)]),
+                   "B,D,F");
+
+        assert_eq!(super::parse_transform_fields(&re, &"A,B,C,D,E,F",
+                                                 &vec![LeftInf(3),
+                                                       LeftInf(-5),
+                                                       LeftInf(-6)]),
+                   "A,B,C,A,");
+
+        assert_eq!(super::parse_transform_fields(&re, &"A,B,C,D,E,F",
+                                                 &vec![RightInf(4),
+                                                       RightInf(-2),
+                                                       RightInf(-1),
+                                                       RightInf(7)]),
+                   "E,FE,FF");
+
+        assert_eq!(super::parse_transform_fields(&re, &"A,B,C,D,E,F",
+                                                 &vec![Both(2,3),
+                                                       Both(-9,2),
+                                                       Both(5,10),
+                                                       Both(-9,-4)]),
+                   "C,A,B,FA,B,");
+    }
+
+    #[test]
+    fn test_parse_matching_fields() {
+        // delimiter is ","
+        let re = Regex::new(".*?,").unwrap();
+
+        assert_eq!(super::parse_matching_fields(&re, &"中,华,人,民,E,F",
+                                                &vec![Single(1),
+                                                      Single(3),
+                                                      Single(-1),
+                                                      Single(-7)]),
+                   vec![(2,4), (6,8), (10,11)]);
+
+        assert_eq!(super::parse_matching_fields(&re, &"中,华,人,民,E,F",
+                                                &vec![LeftInf(3),
+                                                      LeftInf(-5),
+                                                      LeftInf(-6)]),
+                   vec![(0, 6), (0, 2)]);
+
+        assert_eq!(super::parse_matching_fields(&re, &"中,华,人,民,E,F",
+                                                &vec![RightInf(4),
+                                                      RightInf(-2),
+                                                      RightInf(-1),
+                                                      RightInf(7)]),
+                   vec![(8, 11), (8, 11), (10, 11)]);
+
+        assert_eq!(super::parse_matching_fields(&re, &"中,华,人,民,E,F",
+                                                &vec![Both(2,3),
+                                                      Both(-9,2),
+                                                      Both(5,10),
+                                                      Both(-9,-4)]),
+                   vec![(4, 6), (0, 4), (10,11), (0, 4)]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,9 @@ fn real_main() -> i32 {
     opts.optflag("i", "interactive", "Use skim as an interactive interface");
     opts.optflag("", "regex", "use regex instead of fuzzy match");
     opts.optopt("q", "query", "specify the initial query", "\"\"");
+    opts.optopt("d", "delimiter", "specify the delimiter(in REGEX) for fields", "\\t");
+    opts.optopt("n", "nth", "specify the fields to be matched", "1,2..5");
+    opts.optopt("", "with-nth", "specify the fields to be transformed", "1,2..5");
 
     let default_options = match env::var("SKIM_DEFAULT_OPTIONS") {
         Ok(val) => val,

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -286,6 +286,11 @@ fn match_item_fuzzy(index: usize, item: &Item, query: &Query, criterion: &[RankC
 
     let begin = *matched_range.get(0).unwrap_or(&0) as i64;
     let end = *matched_range.last().unwrap_or(&0) as i64;
+
+    if !query.empty() && !item.in_matching_range(begin as usize, (end+1) as usize) {
+        return None;
+    }
+
     let rank = build_rank(criterion, -score, index as i64, begin, end);
 
     let mut item = MatchedItem::new(index);
@@ -306,6 +311,11 @@ fn match_item_regex(index: usize, item: &Item, query: &Query, criterion: &[RankC
     }
 
     let (begin, end) = matched_result.unwrap();
+
+    if !query.empty() && !item.in_matching_range(begin, end) {
+        return None;
+    }
+
     let score = end - begin;
     let rank = build_rank(criterion, score as i64, index as i64, begin as i64, end as i64);
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -130,7 +130,7 @@ impl Model {
         selected.sort();
         let items = self.items.read().unwrap();
         for index in selected {
-            println!("{}", items[*index].text);
+            println!("{}", items[*index].get_orig_text());
         }
     }
 
@@ -238,7 +238,7 @@ impl Model {
                     0
                 };
 
-                let (text, mut idx) = reshape_string(&item.text.chars().collect::<Vec<char>>(),
+                let (text, mut idx) = reshape_string(&item.get_text().chars().collect::<Vec<char>>(),
                                                      (self.max_x-3) as usize,
                                                      self.hscroll_offset,
                                                      matched_end_pos);
@@ -292,7 +292,7 @@ impl Model {
             }
             Some(MatchedRange::Range(start, end)) => {
                 // pass
-                let (text, mut idx) = reshape_string(&item.text.chars().collect::<Vec<char>>(),
+                let (text, mut idx) = reshape_string(&item.get_text().chars().collect::<Vec<char>>(),
                                                      (self.max_x-3) as usize,
                                                      self.hscroll_offset,
                                                      end);

--- a/src/model.rs
+++ b/src/model.rs
@@ -128,9 +128,9 @@ impl Model {
 
         let mut selected = self.selected_indics.iter().collect::<Vec<&usize>>();
         selected.sort();
-        let items = self.items.read().unwrap();
+        let mut items = self.items.write().unwrap();
         for index in selected {
-            println!("{}", items[*index].get_orig_text());
+            println!("{}", items[*index].get_output_text());
         }
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -38,7 +38,7 @@ impl Reader {
                default_arg: String::new(),
                transform_fields: Vec::new(),
                matching_fields: Vec::new(),
-               delimiter: Regex::new(".*? ").unwrap(),
+               delimiter: Regex::new(r".*?\t").unwrap(),
         }
     }
 


### PR DESCRIPTION
## What is this feature?

Sometimes the input to `skim` is quite complicated, and we don't want to display them all in `skim`, nevertheless, they are essential for the next pipe.

For example, we got the output from `ag`: `<filename>:<lineno> <content>`, and we don't want to matching `lineno`, but it is important if we want to further pipe it to vim or some other commands so as to jump to the corresponding line of that file.

Some other times, we want to specify that display additional information and don't want them to be matched.

For example, we can get all history commands for `history`, the format is: `<index> <content>`. We want to display `<index>`, but don't want to match it when we input numbers.

These are just example, the important thing is this field feature can be helpful if you want to extend `skim` to implement subtle features.

## How to use?

The delimiter is specified with `-d <regex>`, it defaults to `-d '\t'`.

Now take `,` as delimiter, so `aa,bb,cc,dd` is split to `aa,`, `bb,`, `cc,` and `dd`. Note here that delimiter itself is included.

Now use `--with-nth=range1,range2,..` to specify the fields that you want to displayed, and `--nth=range1,range2,..` to specify which fields you want to match.

The range is just like Git's range:
1. `<num>` to select the `<num>`-th field, starting from `0`.
2. `start..` to select the `start`-th field and the rest.
3. `..end` to select the `0`-th to the `end`-th fields, excluding the `end`-th field.
4. `start..end` to select the from the `start` to the `end`. Including `start`, excluding `end`.

```
Negative number can be used to index
 0  1  2  3  4  5
-6 -5 -4 -3 -2 -1
```