### PR TITLE
Clippy run

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -19,7 +19,7 @@ pub fn parse_ansi(text: &str) -> (String, Vec<(usize, attr_t)>) {
     // Because ANSI color code can affect text of next lines. We will save the last attribute and
     // add it to the newest line if no new color is specified.
     match RE.find(text) {
-        Some((start, _)) if start <= 0 => {}
+        Some((start, _)) if start == 0 => {}
         Some(_) | None => {
             last_attr.map(|attr| {
                 colors.push((0, attr));
@@ -59,7 +59,7 @@ fn interpret_code(code: &str) -> Option<attr_t> {
     let mut use_fg = true;
 
     let code = &code[2..code.len()-1]; // ^[[1;30;40m -> 1;30;40
-    if code.len() == 0 {
+    if code.is_empty() {
         return None;
     }
 

--- a/src/curses.rs
+++ b/src/curses.rs
@@ -38,7 +38,7 @@ pub fn init(theme: Option<&ColorTheme>, is_black: bool, _use_mouse: bool) {
             DEFAULT16
         };
 
-        init_pairs(&base_theme, &theme, is_black);
+        init_pairs(&base_theme, theme, is_black);
         *use_color = true;
     } else {
         *use_color = false;
@@ -180,10 +180,7 @@ fn shadow(default: i16, x: i16) -> i16 {
 
 
 fn attr_color(pair: i16, is_bold: bool) -> attr_t {
-    let mut attr = 0;
-    if pair > COLOR_NORMAL {
-        attr = COLOR_PAIR(pair);
-    }
+    let attr = if pair > COLOR_NORMAL {COLOR_PAIR(pair)} else {0};
 
     attr | if is_bold {A_BOLD()} else {0}
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -129,7 +129,7 @@ impl KeyBoard {
     }
 
     pub fn get_key(&mut self) -> Option<Key> {
-        if self.buf.len() <= 0 {
+        if self.buf.is_empty() {
             self.get_chars();
         }
 
@@ -492,4 +492,3 @@ fn get_default_key_map() -> HashMap<Key, (Event, Option<String>)> {
     ret.insert(Key::CtrlY, (Event::EvActYank, None));
     ret
 }
-

--- a/src/item.rs
+++ b/src/item.rs
@@ -62,7 +62,7 @@ impl Item {
 
         let lower_chars = ret.get_text().to_lowercase().chars().collect();
         let matching_ranges = if matching_fields.len() > 0 {
-            parse_matching_fields(delimiter, &ret.get_text(), matching_fields)
+            parse_matching_fields(delimiter, ret.get_text(), matching_fields)
         } else {
             Vec::new()
         };
@@ -100,16 +100,12 @@ impl Item {
     }
 
     pub fn in_matching_range(&self, begin: usize, end: usize) -> bool {
-        if self.matching_ranges.len() <= 0 {
-            return true;
-        }
-
         for &(start, stop) in self.matching_ranges.iter() {
             if begin >= start && end <= stop {
                 return true;
             }
         }
-        false
+        self.matching_ranges.is_empty()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn real_main() -> i32 {
     };
 
     let mut args = Vec::new();
-    for option in default_options.split(" ") {
+    for option in default_options.split(' ') {
         args.push(option.to_string());
     }
 
@@ -107,7 +107,7 @@ fn real_main() -> i32 {
     unsafe {
         sigemptyset(&mut sigset);
         sigaddset(&mut sigset, libc::SIGWINCH);
-        pthread_sigmask(libc::SIG_SETMASK, &mut sigset, ptr::null_mut());
+        pthread_sigmask(libc::SIG_SETMASK, &sigset, ptr::null_mut());
     }
 
     // controller variables
@@ -119,7 +119,7 @@ fn real_main() -> i32 {
         // listen to the resize event;
         loop {
             let mut sig = 0;
-            let _errno = unsafe {sigwait(&mut sigset, &mut sig)};
+            let _errno = unsafe {sigwait(&sigset, &mut sig)};
             eb_clone.set(Event::EvResize, Box::new(true));
         }
     });

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -49,7 +49,7 @@ impl<'a> Matcher {
                eb_notify: Arc<EventBox<Event>>) -> Self {
 
         let mut cache = HashMap::new();
-        cache.entry("".to_string()).or_insert(MatcherCache::new());
+        cache.entry("".to_string()).or_insert_with(MatcherCache::new);
 
         Matcher {
             eb_req: Arc::new(EventBox::new()),
@@ -89,7 +89,7 @@ impl<'a> Matcher {
 
         if let Some(query) = options.opt_str("q") {
             self.query = Query::new(&query);
-            self.cache.entry(query.to_string()).or_insert(MatcherCache::new());
+            self.cache.entry(query.to_string()).or_insert_with(MatcherCache::new);
         }
     }
 
@@ -128,7 +128,7 @@ impl<'a> Matcher {
 
                     for i in start..end {
                         let ref item = items[i];
-                        if let Some(matched) = match_item(i, &item, &query, &criterion, algorithm) {
+                        if let Some(matched) = match_item(i, item, &query, &criterion, algorithm) {
                             let _ = tx.send(Some(matched));
                         }
                     }
@@ -221,7 +221,7 @@ impl<'a> Matcher {
             self.new_items.write().unwrap().clear();
             self.cache.remove(&query.to_string());
         }
-        self.cache.entry(query.to_string()).or_insert(MatcherCache::new());
+        self.cache.entry(query.to_string()).or_insert_with(MatcherCache::new);
     }
 
     pub fn run(&mut self) {

--- a/src/orderedvec.rs
+++ b/src/orderedvec.rs
@@ -60,11 +60,11 @@ impl<T> OrderedVec<T> where T: Ord {
             self.sorted = true;
         }
 
-        return self.unordered.get(index - self.ordered.len());
+        self.unordered.get(index - self.ordered.len())
     }
 
     pub fn len(&self) -> usize {
-        return self.ordered.len() + self.unordered.len();
+        self.ordered.len() + self.unordered.len()
     }
 
     pub fn clear(&mut self) {

--- a/src/query.rs
+++ b/src/query.rs
@@ -39,6 +39,7 @@ impl Query {
     }
 
     pub fn backward_char(&mut self) {
+        if self.index == 0 { return; }
         if let Some(ch) = self.query.get(self.index-1) {
             self.index -= 1;
             self.pos -= if ch.len_utf8() > 1 {2} else {1};
@@ -164,5 +165,16 @@ impl Query {
             modified = self.backward_delete_char() || modified;
         }
         modified
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Query;
+
+    #[test]
+    fn test_backward_char() {
+        // Test that going back from zero does not overflow.
+        Query::new().backward_char();
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,3 +1,4 @@
+#[derive(Default)]
 pub struct Query {
     query: Vec<char>,
     pub index: usize,
@@ -6,11 +7,7 @@ pub struct Query {
 
 impl Query {
     pub fn new() -> Self {
-        Query {
-            query: Vec::new(),
-            index: 0,
-            pos: 0,
-        }
+        Default::default()
     }
 
     pub fn new_with_query(query: &str) -> Self {
@@ -29,7 +26,7 @@ impl Query {
         self.query.insert(self.index, ch);
         self.index += 1;
         self.pos += if ch.len_utf8() > 1 {2} else {1};
-        return true;
+        true
     }
 
     pub fn backward_delete_char(&mut self) -> bool{
@@ -38,20 +35,14 @@ impl Query {
         let ch = self.query.remove(self.index-1);
         self.index -= 1;
         self.pos -= if ch.len_utf8() > 1 {2} else {1};
-        return true;
+        true
     }
 
-    pub fn backward_char(&mut self) -> bool {
-        if self.index <= 0 { return false; }
-
-        match self.query.get(self.index-1) {
-            Some(ch) => {
-                self.index -= 1;
-                self.pos -= if ch.len_utf8() > 1 {2} else {1};
-            }
-            None => {}
+    pub fn backward_char(&mut self) {
+        if let Some(ch) = self.query.get(self.index-1) {
+            self.index -= 1;
+            self.pos -= if ch.len_utf8() > 1 {2} else {1};
         }
-        false
     }
 
     pub fn backward_kill_word(&mut self) -> bool {
@@ -106,40 +97,28 @@ impl Query {
         if self.index == self.query.len() { return false; }
 
         let _ = self.query.remove(self.index);
-        return true;
+        true
     }
 
-    pub fn forward_char(&mut self) -> bool {
-        if self.index == self.query.len() { return false; }
-
-        match self.query.get(self.index) {
-            Some(ch) => {
-                self.index += 1;
-                self.pos += if ch.len_utf8() > 1 {2} else {1};
-            }
-            None => {}
+    pub fn forward_char(&mut self) {
+        if let Some(ch) = self.query.get(self.index) {
+            self.index += 1;
+            self.pos += if ch.len_utf8() > 1 {2} else {1};
         }
-        false
     }
 
-    pub fn forward_word(&mut self) -> bool {
-        let len = self.query.len();
+    pub fn forward_word(&mut self) {
         // skip whitespace
-        while self.index < len {
-            if let Some(&' ') = self.query.get(self.index) {
-                self.forward_char();
-            } else {
-                break;
-            }
+        while let Some(_) = self.query.get(self.index) {
+            self.forward_char();
         }
 
-        while self.index < len {
+        loop {
             match self.query.get(self.index) {
-                Some(&ch) if ch != ' ' => { self.forward_char(); }
-                Some(_) | None => {break;}
+                Some(&ch) if ch != ' ' => self.forward_char(),
+                Some(_) | None => break
             }
         }
-        false
     }
 
     pub fn kill_word(&mut self) -> bool {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -118,15 +118,12 @@ impl Reader {
             });
 
             for (e, val) in self.eb_req.wait() {
-                match e {
-                    Event::EvReaderResetQuery => {
-                        let mut items = self.items.write().unwrap();
-                        items.clear();
-                        arg = *val.downcast::<String>().unwrap();
-                        self.eb.set(Event::EvReaderSync, Box::new(true));
-                        let _ = self.eb_req.wait_for(Event::EvModelAck);
-                    }
-                    _ => {}
+                if e == Event::EvReaderResetQuery {
+                    let mut items = self.items.write().unwrap();
+                    items.clear();
+                    arg = *val.downcast::<String>().unwrap();
+                    self.eb.set(Event::EvReaderSync, Box::new(true));
+                    let _ = self.eb_req.wait_for(Event::EvModelAck);
                 }
             }
         }
@@ -137,11 +134,11 @@ impl Reader {
             let mut input = String::new();
             match source.read_line(&mut input) {
                 Ok(n) => {
-                    if n <= 0 { break; }
+                    if n == 0 { break; }
 
-                    if input.ends_with("\n") {
+                    if input.ends_with('\n') {
                         input.pop();
-                        if input.ends_with("\r") {
+                        if input.ends_with('\r') {
                             input.pop();
                         }
                     }
@@ -182,7 +179,7 @@ fn parse_range(range: &str) -> Option<FieldRange> {
     }
 
     let range_string: Vec<&str> = range.split("..").collect();
-    if range_string.len() <= 0 || range_string.len() > 2 {
+    if range_string.is_empty() || range_string.len() > 2 {
         return None;
     }
 

--- a/src/score.rs
+++ b/src/score.rs
@@ -74,7 +74,7 @@ pub fn fuzzy_match(choice: &[char],
                 }
             }
 
-            if vec.len() <= 0 {
+            if vec.is_empty() {
                 // not matched
                 return None;
             }

--- a/src/util/eventbox.rs
+++ b/src/util/eventbox.rs
@@ -145,7 +145,7 @@ fn set_event_throttle<T>(mutex: &Arc<Mutex<EventData<T>>>, cond: &Arc<Condvar>, 
         }
     }
 
-    set_event(&mutex, &cond, e, value);
+    set_event(mutex, cond, e, value);
 
     let mutex = mutex.clone();
     let cond = cond.clone();


### PR DESCRIPTION
Fix bunch of lints suggested by clippy and some other refactorings. I'm unsure about removing the return value of some methods in `query.rs` that always returned the same value. Perhaps you meant to change that later? I'm willing to revert any unwanted changes.