### PR TITLE
fix #27, api change of ncurses-rs causes build error.

### DIFF
--- a/src/curses.rs
+++ b/src/curses.rs
@@ -133,7 +133,7 @@ impl Curses {
     pub fn get_maxyx(&self) -> (i32, i32) {
         let mut max_y = 0;
         let mut max_x = 0;
-        getmaxyx(stdscr, &mut max_y, &mut max_x);
+        getmaxyx(stdscr(), &mut max_y, &mut max_x);
         (max_y, max_x)
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -347,7 +347,7 @@ impl Model {
             // handle tabstop
             let mut y = 0;
             let mut x = 0;
-            getyx(stdscr, &mut y, &mut x);
+            getyx(stdscr(), &mut y, &mut x);
             let rest = (self.tabstop as i32) - (x-2)%(self.tabstop as i32);
             for _ in 0..rest {
                 self.curses.caddch(' ', color, is_bold);


### PR DESCRIPTION
ncurses-rs change the usage of `stdscr` to a function call `stdscr()`.