### PR TITLE
refactor: use filter_map instead of map then filter

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -116,9 +116,7 @@ impl Matcher {
 
                         matcher_engine.as_ref().map(|mat| {
                             let matched_items: MatchedItemGroup = items.into_iter()
-                                .map(|item| mat.match_item(item))
-                                .filter(Option::is_some)
-                                .map(|item| item.unwrap())
+                                .filter_map(|item| mat.match_item(item))
                                 .collect();
                             let _ = self.tx_result.send((Event::EvModelNewItem, Box::new(matched_items)));
                         });

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -58,21 +58,17 @@ impl ReaderOption {
 
         if let Some(transform_fields) = options.opt_str("with-nth") {
             self.transform_fields = transform_fields.split(',')
-                .map(|string| {
+                .filter_map(|string| {
                     parse_range(string)
                 })
-                .filter(|range| range.is_some())
-                .map(|range| range.unwrap())
                 .collect();
         }
 
         if let Some(matching_fields) = options.opt_str("nth") {
             self.matching_fields = matching_fields.split(',')
-                .map(|string| {
+                .filter_map(|string| {
                     parse_range(string)
                 })
-                .filter(|range| range.is_some())
-                .map(|range| range.unwrap())
                 .collect();
         }
     }


### PR DESCRIPTION
I think map then filter can be changed into filter_map. It's simpler and faster.