### PR TITLE
Fix some compilation warnings

### DIFF
--- a/src/curses.rs
+++ b/src/curses.rs
@@ -6,7 +6,6 @@ use std::sync::RwLock;
 use std::collections::HashMap;
 use libc::{STDIN_FILENO, STDERR_FILENO, fdopen};
 
-use std::io::Write;
 macro_rules! println_stderr(
     ($($arg:tt)*) => { {
         let r = writeln!(&mut ::std::io::stderr(), $($arg)*);

--- a/src/item.rs
+++ b/src/item.rs
@@ -10,7 +10,6 @@ use std::borrow::Cow;
 use std::ascii::AsciiExt;
 use std::sync::Arc;
 
-use std::io::Write;
 macro_rules! println_stderr(
     ($($arg:tt)*) => { {
         let r = writeln!(&mut ::std::io::stderr(), $($arg)*);

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,6 @@ use std::ptr;
 use libc::{sigemptyset, sigaddset, sigwait, pthread_sigmask};
 use curses::Curses;
 
-use std::io::Write;
 macro_rules! println_stderr(
     ($($arg:tt)*) => { {
         let r = writeln!(&mut ::std::io::stderr(), $($arg)*);

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -6,7 +6,6 @@ use std::thread;
 
 use getopts;
 use score;
-use std::io::Write;
 use regex::Regex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;

--- a/src/model.rs
+++ b/src/model.rs
@@ -7,12 +7,10 @@ use orderedvec::OrderedVec;
 use std::sync::Arc;
 use std::collections::HashMap;
 
-use curses::{ColorTheme, Curses};
 use curses::*;
 use curses;
 use getopts;
 
-use std::io::Write;
 macro_rules! println_stderr(
     ($($arg:tt)*) => { {
         let r = writeln!(&mut ::std::io::stderr(), $($arg)*);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 use std::collections::HashMap;
 use std::mem;
 
-use std::io::Write;
 use getopts;
 use regex::Regex;
 use sender::CachedSender;

--- a/src/score.rs
+++ b/src/score.rs
@@ -16,7 +16,6 @@ const PENALTY_LEADING: i64 = -6; // penalty applied for every letter before the 
 const PENALTY_MAX_LEADING: i64 = -18; // maxing penalty for leading letters
 const PENALTY_UNMATCHED: i64 = -2;
 
-use std::io::Write;
 macro_rules! println_stderr(
     ($($arg:tt)*) => { {
         let r = writeln!(&mut ::std::io::stderr(), $($arg)*);

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -4,7 +4,6 @@ use event::{Event, EventArg};
 use std::thread;
 use std::time::Duration;
 
-use std::io::Write;
 macro_rules! println_stderr(
     ($($arg:tt)*) => { {
         let r = writeln!(&mut ::std::io::stderr(), $($arg)*);


### PR DESCRIPTION
Removed some unused imports throwing warnings and a double import giving me a compiler error in `src/model.rs`.

Note: The `cmd` and `query` functions in `src/query.rs` are currently dead
code.