### PR TITLE
Resolve private functions used in tests

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -631,7 +631,7 @@ pub fn parse_criteria(text: &str) -> Option<RankCriteria> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use super::{MatcherMode, EngineFactory};
 
     #[test]
     fn test_engine_factory() {

--- a/src/model.rs
+++ b/src/model.rs
@@ -746,8 +746,8 @@ fn reshape_string(text: &[char],
 }
 
 #[cfg(test)]
-mod test {
-    use super::*;
+mod tests {
+    use super::{rune_width, accumulate_text_width, reshape_string};
 
     fn to_chars(s: &str) -> Vec<char> {
         s.to_string().chars().collect()

--- a/src/query.rs
+++ b/src/query.rs
@@ -42,10 +42,11 @@ impl Query {
     }
 
     // currently they are not used, but will in the future
-    //pub fn query(mut self, query: &str) -> Self {
-        //self.query_before = query.chars().collect();
-        //self
-    //}
+    #[cfg(test)]
+    pub fn query(mut self, query: &str) -> Self {
+        self.query_before = query.chars().collect();
+        self
+    }
 
     //pub fn cmd(mut self, cmd: &str) -> Self {
         //self.cmd_before = cmd.chars().collect();


### PR DESCRIPTION
These functions are not pub and so can't be picked up with the glob syntax. Importing them explicitly works. This should fix the Travis builds.