### PR TITLE
Fix file selection completion. fixes #51

### DIFF
--- a/plugin/skim.vim
+++ b/plugin/skim.vim
@@ -341,7 +341,7 @@ function! s:execute_term(dict, command, temps) abort
       endif
     endif
   endfunction
-  function! skim.on_exit(id, code)
+  function! skim.on_exit(id, code, _event)
     if s:getpos() == self.ppos " {'window': 'enew'}
       for [opt, val] in items(self.winopts)
         execute 'let' opt '=' val


### PR DESCRIPTION
As @justinmk pointed out, `on_exit` is a `system_handler`, that's
taking 3 parameters:
https://github.com/neovim/neovim/blob/25427ae892ccbb537a718c8abfbd4c79d9f94091/runtime/autoload/man.vim#L71-L90

This fixes file selection crash (in my setup neovim + rg).