### PR TITLE
fix #72 use `width()` instead of `cjk_width()`

### DIFF
--- a/src/curses.rs
+++ b/src/curses.rs
@@ -412,7 +412,7 @@ impl Window {
     fn add_char_raw(&mut self, ch: char) {
         let (max_y, max_x) = self.get_maxyx();
         let (y, x) = self.getyx();
-        let text_width = ch.width_cjk().unwrap_or(2) as u16;
+        let text_width = ch.width().unwrap_or(2) as u16;
         let target_x = x + text_width;
 
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -846,7 +846,7 @@ impl LinePrinter {
     }
 
     fn caddch(&mut self, curses: &mut Window, ch: char, color: u16, is_bold: bool, skip: bool) {
-        let w = ch.width_cjk().unwrap_or(2);
+        let w = ch.width().unwrap_or(2);
 
         if skip {
             curses.move_cursor_right(w as u16);
@@ -859,7 +859,7 @@ impl LinePrinter {
         // hide the content that outside the screen, and show the hint(i.e. `..`) for overflow
         // the hidden chracter
 
-        let w = ch.width_cjk().unwrap_or(2);
+        let w = ch.width().unwrap_or(2);
 
         assert!(self.current >= 0);
         let current = self.current as usize;
@@ -911,7 +911,7 @@ fn accumulate_text_width(text: &[char], tabstop: usize) -> Vec<usize> {
         w += if ch == '\t' {
             tabstop - (w % tabstop)
         } else {
-            ch.width_cjk().unwrap_or(2)
+            ch.width().unwrap_or(2)
         };
         ret.push(w);
     }


### PR DESCRIPTION
skim use unicode-width crate for the calculation of the number of
columns a character occupies. According to the documentation there are
several characters that sit between "halfwidth" and "fullwidth".
`width_cjk` will treat these characters as 2 columns while `width` will
treat them as 1 column.

Since my assumption about the usage of skim is under non-CJK context,
`width` will be a better choice over `cjk_width`.