### PR TITLE
change the field syntax to fzf's style

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ finally decide which lines to pick by checking the context around the line.
 window. For example:
 
 ```
-sk --ansi -i -c 'ag --color "{}"' --preview "preview.sh {0}"
+sk --ansi -i -c 'ag --color "{}"' --preview "preview.sh {}"
 ```
 
 (Note the [preview.sh](https://github.com/junegunn/fzf.vim/blob/master/bin/preview.sh) is a script to print the context given filename:lines:columns)
@@ -345,7 +345,7 @@ with the current highlighted line surrounded by single quote. Then call the
 command to get the output. And print the output on the preview window.
 
 Sometimes you don't need the whole line for invoking the command, in this case
-you can use `{0}`, `{1..}`, `{..3}` or `{1..5}` to select the fields. The
+you can use `{}`, `{1..}`, `{..3}` or `{1..5}` to select the fields. The
 syntax is explained in the section "Fields Support".
 
 Last, you might want to configure the position of preview windows, use
@@ -371,18 +371,18 @@ However, you want to search `<filename>` only when typing in queries. That
 means when you type `21`, you want to find a `<filename>` that contains `21`,
 but not matching line number or column number.
 
-You can use `sk --delimiter ':' --nth 0` to achieve this.
+You can use `sk --delimiter ':' --nth 1` to achieve this.
 
 Also you can use `--with-nth` to re-arrange the order of fields.
 
 **Range Syntax**
 
-- `<num>` -- to specify the `num`-th fields, starting with 0.
+- `<num>` -- to specify the `num`-th fields, starting with 1.
 - `start..` -- starting from the `start`-th fields, and the rest.
 - `..end` -- starting from the `0`-th field, all the way to `end`-th field,
-    excluding `end`.
+    including `end`.
 - `start..end` -- starting from `start`-th field, all the way to `end`-th
-    field, excluding `end`.
+    field, including `end`.
 
 ## Use as a library
 
@@ -466,7 +466,7 @@ different from fzf. For example:
 2. ~~UI of showing matched items. `fzf` will show only the range matched while
    `skim` will show each character matched.~~ (fzf has this now)
 3. `skim` has an interactive mode.
-4. `skim`'s range syntax is git style.
+4. ~~`skim`'s range syntax is git style~~: now it is the same with fzf.
 
 # How to contribute
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,14 +1,111 @@
 use regex::Regex;
+use std::cmp::{min, max};
+
+lazy_static! {
+    static ref FIELD_RANGE: Regex = Regex::new(r"^(?P<left>-?\d+)?(?P<sep>\.\.)?(?P<right>-?\d+)?$").unwrap();
+}
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum FieldRange {
-    Single(i64),
-    LeftInf(i64),
-    RightInf(i64),
-    Both(i64, i64),
+    Single(i32),
+    LeftInf(i32),
+    RightInf(i32),
+    Both(i32, i32),
 }
+
+impl FieldRange {
+    pub fn from_str(range: &str) -> Option<FieldRange> {
+        use self::FieldRange::*;
+
+        // "1", "1..", "..10", "1..10", etc.
+        let opt_caps = FIELD_RANGE.captures(range);
+        if let Some(caps) = opt_caps {
+            let opt_left = caps.name("left").map(|s| s.as_str().parse().unwrap_or(1));
+            let opt_right = caps.name("right").map(|s| s.as_str().parse().unwrap_or(-1));
+            let opt_sep = caps.name("sep").map(|s| s.as_str().to_string());
+
+            if opt_left.is_none() && opt_right.is_none() {
+                // ..
+                Some(RightInf(0))
+            } else if opt_right.is_none() {
+                if opt_sep.is_none() {
+                    // 1
+                    Some(Single(opt_left.unwrap()))
+                } else {
+                    // 1..
+                    Some(RightInf(opt_left.unwrap()))
+                }
+            } else if opt_left.is_none() {
+                if opt_sep.is_none() {
+                    // 1 (should not happen)
+                    Some(Single(opt_right.unwrap()))
+                } else {
+                    // ..1 (should not happen)
+                    Some(LeftInf(opt_right.unwrap()))
+                }
+            } else {
+                // 1..3
+                Some(Both(opt_left.unwrap(), opt_right.unwrap()))
+            }
+        } else {
+            None
+        }
+    }
+
+    // Parse FieldRange to index pair (left, right)
+    // e.g. 1..3 => (0, 4)
+    // note that field range is inclusive while the output index will exclude right end
+    pub fn to_index_pair(&self, length: usize) -> Option<(usize, usize)> {
+        use self::FieldRange::*;
+        match *self {
+            Single(num) => {
+                let num = FieldRange::translate_neg(num, length);
+                if num == 0 || num > length {
+                    None
+                } else {
+                    Some((num-1, num))
+                }
+            }
+            LeftInf(right) => {
+                let right = FieldRange::translate_neg(right, length);
+                if length == 0 || right == 0 {
+                    None
+                } else {
+                    let right = min(right, length);
+                    Some((0, right))
+                }
+            }
+            RightInf(left) => {
+                let left = FieldRange::translate_neg(left, length);
+                if length == 0 || left > length {
+                    None
+                } else {
+                    let left = max(left, 1);
+                    Some((left-1, length))
+                }
+            }
+            Both(left, right) => {
+                let left = FieldRange::translate_neg(left, length);
+                let right = FieldRange::translate_neg(right, length);
+                if length == 0 || left > right || right <= 0 || left > length {
+                    None
+                } else {
+                    Some((max(left, 1)-1, min(right, length)))
+                }
+            }
+        }
+    }
+
+    fn translate_neg(idx: i32, length: usize) -> usize {
+        let len = length as i32;
+        let idx = if idx < 0 {idx + len + 1} else {idx};
+        max(0, idx) as usize
+    }
+}
+
+
 // e.g. delimiter = Regex::new(",").unwrap()
-// Note that this is differnt with `parse_field_range`, it uses delimiters like ".*?,"
+// Note that this is differnt with `to_index_pair`, it uses delimiters like ".*?,"
 pub fn get_string_by_field<'a>(delimiter: &Regex, text: &'a str, field: &FieldRange) -> Option<&'a str> {
     let mut ranges = Vec::new();
     let mut last = 0;
@@ -18,7 +115,7 @@ pub fn get_string_by_field<'a>(delimiter: &Regex, text: &'a str, field: &FieldRa
     }
     ranges.push((last, text.len()));
 
-    if let Some((start, stop)) = parse_field_range(field, ranges.len()) {
+    if let Some((start, stop)) = field.to_index_pair(ranges.len()) {
         let &(begin, _) = &ranges[start];
         let &(_, end) = ranges.get(stop - 1).unwrap_or(&(text.len(), 0));
         Some(&text[begin..end])
@@ -28,7 +125,7 @@ pub fn get_string_by_field<'a>(delimiter: &Regex, text: &'a str, field: &FieldRa
 }
 
 pub fn get_string_by_range<'a>(delimiter: &Regex, text: &'a str, range: &str) -> Option<&'a str> {
-    parse_range(range).and_then(|field| get_string_by_field(delimiter, text, &field))
+    FieldRange::from_str(range).and_then(|field| get_string_by_field(delimiter, text, &field))
 }
 
 // -> a vector of the matching fields.
@@ -42,7 +139,7 @@ pub fn parse_matching_fields(delimiter: &Regex, text: &str, fields: &[FieldRange
 
     let mut ret = Vec::new();
     for field in fields {
-        if let Some((start, stop)) = parse_field_range(field, ranges.len()) {
+        if let Some((start, stop)) = field.to_index_pair(ranges.len()) {
             let &(begin, _) = &ranges[start];
             let &(end, _) = ranges.get(stop).unwrap_or(&(text.len(), 0));
             let first = (&text[..begin]).chars().count();
@@ -53,96 +150,9 @@ pub fn parse_matching_fields(delimiter: &Regex, text: &str, fields: &[FieldRange
     ret
 }
 
-// range: "start..end", end is excluded.
-// "0", "0..", "..10", "1..10", etc.
-pub fn parse_range(range: &str) -> Option<FieldRange> {
-    use self::FieldRange::*;
 
-    if range == ".." {
-        return Some(RightInf(0));
-    }
 
-    let range_string: Vec<&str> = range.split("..").collect();
-    if range_string.is_empty() || range_string.len() > 2 {
-        return None;
-    }
 
-    let start = range_string.get(0).and_then(|x| x.parse::<i64>().ok());
-    let end = range_string.get(1).and_then(|x| x.parse::<i64>().ok());
-
-    if range_string.len() == 1 {
-        return if start.is_none() {
-            None
-        } else {
-            Some(Single(start.unwrap()))
-        };
-    }
-
-    if start.is_none() && end.is_none() {
-        None
-    } else if end.is_none() {
-        // 1..
-        Some(RightInf(start.unwrap()))
-    } else if start.is_none() {
-        // ..1
-        Some(LeftInf(end.unwrap()))
-    } else {
-        Some(Both(start.unwrap(), end.unwrap()))
-    }
-}
-
-fn parse_field_range(range: &FieldRange, length: usize) -> Option<(usize, usize)> {
-    let length = length as i64;
-    match *range {
-        FieldRange::Single(index) => {
-            let index = if index >= 0 { index } else { length + index };
-            if index < 0 || index >= length {
-                None
-            } else {
-                Some((index as usize, (index + 1) as usize))
-            }
-        }
-        FieldRange::LeftInf(right) => {
-            let right = if right >= 0 { right } else { length + right };
-            if right <= 0 {
-                None
-            } else {
-                Some((
-                    0,
-                    if right > length {
-                        length as usize
-                    } else {
-                        right as usize
-                    },
-                ))
-            }
-        }
-        FieldRange::RightInf(left) => {
-            let left = if left >= 0 { left } else { length + left };
-            if left >= length {
-                None
-            } else {
-                Some((if left < 0 { 0 } else { left } as usize, length as usize))
-            }
-        }
-        FieldRange::Both(left, right) => {
-            let left = if left >= 0 { left } else { length + left };
-            let right = if right >= 0 { right } else { length + right };
-            if left >= right || left >= length || right < 0 {
-                None
-            } else {
-                Some((
-                    if left < 0 { 0 } else { left as usize },
-                    if right > length {
-                        length as usize
-                    } else {
-                        right as usize
-                    },
-                ))
-            }
-        }
-    }
-}
 
 pub fn parse_transform_fields(delimiter: &Regex, text: &str, fields: &[FieldRange]) -> String {
     let mut ranges = delimiter
@@ -154,7 +164,7 @@ pub fn parse_transform_fields(delimiter: &Regex, text: &str, fields: &[FieldRang
 
     let mut ret = String::new();
     for field in fields {
-        if let Some((start, stop)) = parse_field_range(field, ranges.len()) {
+        if let Some((start, stop)) = field.to_index_pair(ranges.len()) {
             let &(begin, _) = &ranges[start];
             let &(end, _) = ranges.get(stop).unwrap_or(&(text.len(), 0));
             ret.push_str(&text[begin..end]);
@@ -168,72 +178,74 @@ mod test {
     use super::FieldRange::*;
     #[test]
     fn test_parse_range() {
-        assert_eq!(super::parse_range("1"), Some(Single(1)));
-        assert_eq!(super::parse_range("-1"), Some(Single(-1)));
+        assert_eq!(FieldRange::from_str("1"), Some(Single(1)));
+        assert_eq!(FieldRange::from_str("-1"), Some(Single(-1)));
 
-        assert_eq!(super::parse_range("1.."), Some(RightInf(1)));
-        assert_eq!(super::parse_range("-1.."), Some(RightInf(-1)));
+        assert_eq!(FieldRange::from_str("1.."), Some(RightInf(1)));
+        assert_eq!(FieldRange::from_str("-1.."), Some(RightInf(-1)));
 
-        assert_eq!(super::parse_range("..1"), Some(LeftInf(1)));
-        assert_eq!(super::parse_range("..-1"), Some(LeftInf(-1)));
+        assert_eq!(FieldRange::from_str("..1"), Some(LeftInf(1)));
+        assert_eq!(FieldRange::from_str("..-1"), Some(LeftInf(-1)));
 
-        assert_eq!(super::parse_range("1..3"), Some(Both(1, 3)));
-        assert_eq!(super::parse_range("-1..-3"), Some(Both(-1, -3)));
+        assert_eq!(FieldRange::from_str("1..3"), Some(Both(1, 3)));
+        assert_eq!(FieldRange::from_str("-1..-3"), Some(Both(-1, -3)));
 
-        assert_eq!(super::parse_range(".."), Some(RightInf(0)));
-        assert_eq!(super::parse_range("a.."), None);
-        assert_eq!(super::parse_range("..b"), None);
-        assert_eq!(super::parse_range("a..b"), None);
+        assert_eq!(FieldRange::from_str(".."), Some(RightInf(0)));
+        assert_eq!(FieldRange::from_str("a.."), None);
+        assert_eq!(FieldRange::from_str("..b"), None);
+        assert_eq!(FieldRange::from_str("a..b"), None);
     }
 
     use regex::Regex;
 
     #[test]
     fn test_parse_field_range() {
-        assert_eq!(super::parse_field_range(&Single(0), 10), Some((0, 1)));
-        assert_eq!(super::parse_field_range(&Single(9), 10), Some((9, 10)));
-        assert_eq!(super::parse_field_range(&Single(10), 10), None);
-        assert_eq!(super::parse_field_range(&Single(-1), 10), Some((9, 10)));
-        assert_eq!(super::parse_field_range(&Single(-10), 10), Some((0, 1)));
-        assert_eq!(super::parse_field_range(&Single(-11), 10), None);
+        assert_eq!(Single(0).to_index_pair(10), None);
+        assert_eq!(Single(1).to_index_pair(10), Some((0, 1)));
+        assert_eq!(Single(10).to_index_pair(10), Some((9, 10)));
+        assert_eq!(Single(11).to_index_pair(10), None);
+        assert_eq!(Single(-1).to_index_pair(10), Some((9, 10)));
+        assert_eq!(Single(-10).to_index_pair(10), Some((0, 1)));
+        assert_eq!(Single(-11).to_index_pair(10), None);
 
-        assert_eq!(super::parse_field_range(&LeftInf(0), 10), None);
-        assert_eq!(super::parse_field_range(&LeftInf(1), 10), Some((0, 1)));
-        assert_eq!(super::parse_field_range(&LeftInf(8), 10), Some((0, 8)));
-        assert_eq!(super::parse_field_range(&LeftInf(10), 10), Some((0, 10)));
-        assert_eq!(super::parse_field_range(&LeftInf(11), 10), Some((0, 10)));
-        assert_eq!(super::parse_field_range(&LeftInf(-1), 10), Some((0, 9)));
-        assert_eq!(super::parse_field_range(&LeftInf(-8), 10), Some((0, 2)));
-        assert_eq!(super::parse_field_range(&LeftInf(-9), 10), Some((0, 1)));
-        assert_eq!(super::parse_field_range(&LeftInf(-10), 10), None);
-        assert_eq!(super::parse_field_range(&LeftInf(-11), 10), None);
+        assert_eq!(LeftInf(0).to_index_pair(10), None);
+        assert_eq!(LeftInf(1).to_index_pair(10), Some((0, 1)));
+        assert_eq!(LeftInf(8).to_index_pair(10), Some((0, 8)));
+        assert_eq!(LeftInf(10).to_index_pair(10), Some((0, 10)));
+        assert_eq!(LeftInf(11).to_index_pair(10), Some((0, 10)));
+        assert_eq!(LeftInf(-1).to_index_pair(10), Some((0, 10)));
+        assert_eq!(LeftInf(-8).to_index_pair(10), Some((0, 3)));
+        assert_eq!(LeftInf(-9).to_index_pair(10), Some((0, 2)));
+        assert_eq!(LeftInf(-10).to_index_pair(10), Some((0, 1)));
+        assert_eq!(LeftInf(-11).to_index_pair(10), None);
 
-        assert_eq!(super::parse_field_range(&RightInf(0), 10), Some((0, 10)));
-        assert_eq!(super::parse_field_range(&RightInf(1), 10), Some((1, 10)));
-        assert_eq!(super::parse_field_range(&RightInf(8), 10), Some((8, 10)));
-        assert_eq!(super::parse_field_range(&RightInf(10), 10), None);
-        assert_eq!(super::parse_field_range(&RightInf(11), 10), None);
-        assert_eq!(super::parse_field_range(&RightInf(-1), 10), Some((9, 10)));
-        assert_eq!(super::parse_field_range(&RightInf(-8), 10), Some((2, 10)));
-        assert_eq!(super::parse_field_range(&RightInf(-9), 10), Some((1, 10)));
-        assert_eq!(super::parse_field_range(&RightInf(-10), 10), Some((0, 10)));
-        assert_eq!(super::parse_field_range(&RightInf(-11), 10), Some((0, 10)));
+        assert_eq!(RightInf(0).to_index_pair(10), Some((0, 10)));
+        assert_eq!(RightInf(1).to_index_pair(10), Some((0, 10)));
+        assert_eq!(RightInf(8).to_index_pair(10), Some((7, 10)));
+        assert_eq!(RightInf(10).to_index_pair(10), Some((9, 10)));
+        assert_eq!(RightInf(11).to_index_pair(10), None);
+        assert_eq!(RightInf(-1).to_index_pair(10), Some((9, 10)));
+        assert_eq!(RightInf(-8).to_index_pair(10), Some((2, 10)));
+        assert_eq!(RightInf(-9).to_index_pair(10), Some((1, 10)));
+        assert_eq!(RightInf(-10).to_index_pair(10), Some((0, 10)));
+        assert_eq!(RightInf(-11).to_index_pair(10), Some((0, 10)));
 
-        assert_eq!(super::parse_field_range(&Both(0, 0), 10), None);
-        assert_eq!(super::parse_field_range(&Both(0, 1), 10), Some((0, 1)));
-        assert_eq!(super::parse_field_range(&Both(0, 10), 10), Some((0, 10)));
-        assert_eq!(super::parse_field_range(&Both(0, 11), 10), Some((0, 10)));
-        assert_eq!(super::parse_field_range(&Both(1, -1), 10), Some((1, 9)));
-        assert_eq!(super::parse_field_range(&Both(1, -9), 10), None);
-        assert_eq!(super::parse_field_range(&Both(1, -10), 10), None);
-        assert_eq!(super::parse_field_range(&Both(-9, -9), 10), None);
-        assert_eq!(super::parse_field_range(&Both(-9, -8), 10), Some((1, 2)));
-        assert_eq!(super::parse_field_range(&Both(-9, 0), 10), None);
-        assert_eq!(super::parse_field_range(&Both(-9, 1), 10), None);
-        assert_eq!(super::parse_field_range(&Both(-9, 2), 10), Some((1, 2)));
-        assert_eq!(super::parse_field_range(&Both(-1, 0), 10), None);
-        assert_eq!(super::parse_field_range(&Both(11, 20), 10), None);
-        assert_eq!(super::parse_field_range(&Both(-10, -10), 10), None);
+        assert_eq!(Both(0, 0).to_index_pair(10), None);
+        assert_eq!(Both(0, 1).to_index_pair(10), Some((0, 1)));
+        assert_eq!(Both(0, 10).to_index_pair(10), Some((0, 10)));
+        assert_eq!(Both(0, 11).to_index_pair(10), Some((0, 10)));
+        assert_eq!(Both(1, -1).to_index_pair(10), Some((0, 10)));
+        assert_eq!(Both(1, -9).to_index_pair(10), Some((0, 2)));
+        assert_eq!(Both(1, -10).to_index_pair(10), Some((0, 1)));
+        assert_eq!(Both(1, -11).to_index_pair(10), None);
+        assert_eq!(Both(-9, -9).to_index_pair(10), Some((1, 2)));
+        assert_eq!(Both(-9, -8).to_index_pair(10), Some((1, 3)));
+        assert_eq!(Both(-9, 0).to_index_pair(10), None);
+        assert_eq!(Both(-9, 1).to_index_pair(10), None);
+        assert_eq!(Both(-9, 2).to_index_pair(10), Some((1, 2)));
+        assert_eq!(Both(-1, 0).to_index_pair(10), None);
+        assert_eq!(Both(11, 20).to_index_pair(10), None);
+        assert_eq!(Both(-11, -11).to_index_pair(10), None);
     }
 
     #[test]
@@ -242,12 +254,12 @@ mod test {
         let re = Regex::new(".*?,").unwrap();
 
         assert_eq!(
-            super::parse_transform_fields(&re, &"A,B,C,D,E,F", &vec![Single(1), Single(3), Single(-1), Single(-7)]),
+            super::parse_transform_fields(&re, &"A,B,C,D,E,F", &vec![Single(2), Single(4), Single(-1), Single(-7)]),
             "B,D,F"
         );
 
         assert_eq!(
-            super::parse_transform_fields(&re, &"A,B,C,D,E,F", &vec![LeftInf(3), LeftInf(-5), LeftInf(-6)]),
+            super::parse_transform_fields(&re, &"A,B,C,D,E,F", &vec![LeftInf(3), LeftInf(-6), LeftInf(-7)]),
             "A,B,C,A,"
         );
 
@@ -255,7 +267,7 @@ mod test {
             super::parse_transform_fields(
                 &re,
                 &"A,B,C,D,E,F",
-                &vec![RightInf(4), RightInf(-2), RightInf(-1), RightInf(7)]
+                &vec![RightInf(5), RightInf(-2), RightInf(-1), RightInf(8)]
             ),
             "E,FE,FF"
         );
@@ -264,7 +276,7 @@ mod test {
             super::parse_transform_fields(
                 &re,
                 &"A,B,C,D,E,F",
-                &vec![Both(2, 3), Both(-9, 2), Both(5, 10), Both(-9, -4)]
+                &vec![Both(3, 3), Both(-9, 2), Both(6, 10), Both(-9, -5)]
             ),
             "C,A,B,FA,B,"
         );
@@ -279,13 +291,13 @@ mod test {
             super::parse_matching_fields(
                 &re,
                 &"中,华,人,民,E,F",
-                &vec![Single(1), Single(3), Single(-1), Single(-7)]
+                &vec![Single(2), Single(4), Single(-1), Single(-7)]
             ),
             vec![(2, 4), (6, 8), (10, 11)]
         );
 
         assert_eq!(
-            super::parse_matching_fields(&re, &"中,华,人,民,E,F", &vec![LeftInf(3), LeftInf(-5), LeftInf(-6)]),
+            super::parse_matching_fields(&re, &"中,华,人,民,E,F", &vec![LeftInf(3), LeftInf(-6), LeftInf(-7)]),
             vec![(0, 6), (0, 2)]
         );
 
@@ -293,7 +305,7 @@ mod test {
             super::parse_matching_fields(
                 &re,
                 &"中,华,人,民,E,F",
-                &vec![RightInf(4), RightInf(-2), RightInf(-1), RightInf(7)]
+                &vec![RightInf(5), RightInf(-2), RightInf(-1), RightInf(7)]
             ),
             vec![(8, 11), (8, 11), (10, 11)]
         );
@@ -302,7 +314,7 @@ mod test {
             super::parse_matching_fields(
                 &re,
                 &"中,华,人,民,E,F",
-                &vec![Both(2, 3), Both(-9, 2), Both(5, 10), Both(-9, -4)]
+                &vec![Both(3, 3), Both(-8, 2), Both(6, 10), Both(-8, -5)]
             ),
             vec![(4, 6), (0, 4), (10, 11), (0, 4)]
         );
@@ -314,18 +326,19 @@ mod test {
         // delimiter is ","
         let re = Regex::new(",").unwrap();
         let text = "a,b,c,";
-        assert_eq!(get_string_by_field(&re, &text, &Single(0)), Some("a"));
-        assert_eq!(get_string_by_field(&re, &text, &Single(1)), Some("b"));
-        assert_eq!(get_string_by_field(&re, &text, &Single(2)), Some("c"));
-        assert_eq!(get_string_by_field(&re, &text, &Single(3)), Some(""));
-        assert_eq!(get_string_by_field(&re, &text, &Single(4)), None);
+        assert_eq!(get_string_by_field(&re, &text, &Single(0)), None);
+        assert_eq!(get_string_by_field(&re, &text, &Single(1)), Some("a"));
+        assert_eq!(get_string_by_field(&re, &text, &Single(2)), Some("b"));
+        assert_eq!(get_string_by_field(&re, &text, &Single(3)), Some("c"));
+        assert_eq!(get_string_by_field(&re, &text, &Single(4)), Some(""));
         assert_eq!(get_string_by_field(&re, &text, &Single(5)), None);
+        assert_eq!(get_string_by_field(&re, &text, &Single(6)), None);
         assert_eq!(get_string_by_field(&re, &text, &Single(-1)), Some(""));
         assert_eq!(get_string_by_field(&re, &text, &Single(-2)), Some("c"));
         assert_eq!(get_string_by_field(&re, &text, &Single(-3)), Some("b"));
         assert_eq!(get_string_by_field(&re, &text, &Single(-4)), Some("a"));
         assert_eq!(get_string_by_field(&re, &text, &Single(-5)), None);
-        assert_eq!(get_string_by_field(&re, &text, &Single(-1)), Some(""));
+        assert_eq!(get_string_by_field(&re, &text, &Single(-6)), None);
 
         assert_eq!(get_string_by_field(&re, &text, &LeftInf(0)), None);
         assert_eq!(get_string_by_field(&re, &text, &LeftInf(1)), Some("a"));
@@ -334,16 +347,16 @@ mod test {
         assert_eq!(get_string_by_field(&re, &text, &LeftInf(4)), Some("a,b,c,"));
         assert_eq!(get_string_by_field(&re, &text, &LeftInf(5)), Some("a,b,c,"));
         assert_eq!(get_string_by_field(&re, &text, &LeftInf(-5)), None);
-        assert_eq!(get_string_by_field(&re, &text, &LeftInf(-4)), None);
-        assert_eq!(get_string_by_field(&re, &text, &LeftInf(-3)), Some("a"));
-        assert_eq!(get_string_by_field(&re, &text, &LeftInf(-2)), Some("a,b"));
-        assert_eq!(get_string_by_field(&re, &text, &LeftInf(-1)), Some("a,b,c"));
+        assert_eq!(get_string_by_field(&re, &text, &LeftInf(-4)), Some("a"));
+        assert_eq!(get_string_by_field(&re, &text, &LeftInf(-3)), Some("a,b"));
+        assert_eq!(get_string_by_field(&re, &text, &LeftInf(-2)), Some("a,b,c"));
+        assert_eq!(get_string_by_field(&re, &text, &LeftInf(-1)), Some("a,b,c,"));
 
         assert_eq!(get_string_by_field(&re, &text, &RightInf(0)), Some("a,b,c,"));
-        assert_eq!(get_string_by_field(&re, &text, &RightInf(1)), Some("b,c,"));
-        assert_eq!(get_string_by_field(&re, &text, &RightInf(2)), Some("c,"));
-        assert_eq!(get_string_by_field(&re, &text, &RightInf(3)), Some(""));
-        assert_eq!(get_string_by_field(&re, &text, &RightInf(4)), None);
+        assert_eq!(get_string_by_field(&re, &text, &RightInf(1)), Some("a,b,c,"));
+        assert_eq!(get_string_by_field(&re, &text, &RightInf(2)), Some("b,c,"));
+        assert_eq!(get_string_by_field(&re, &text, &RightInf(3)), Some("c,"));
+        assert_eq!(get_string_by_field(&re, &text, &RightInf(4)), Some(""));
         assert_eq!(get_string_by_field(&re, &text, &RightInf(5)), None);
         assert_eq!(get_string_by_field(&re, &text, &RightInf(-5)), Some("a,b,c,"));
         assert_eq!(get_string_by_field(&re, &text, &RightInf(-4)), Some("a,b,c,"));
@@ -357,15 +370,18 @@ mod test {
         assert_eq!(get_string_by_field(&re, &text, &Both(0, 3)), Some("a,b,c"));
         assert_eq!(get_string_by_field(&re, &text, &Both(0, 4)), Some("a,b,c,"));
         assert_eq!(get_string_by_field(&re, &text, &Both(0, 5)), Some("a,b,c,"));
-        assert_eq!(get_string_by_field(&re, &text, &Both(1, 5)), Some("b,c,"));
-        assert_eq!(get_string_by_field(&re, &text, &Both(2, 5)), Some("c,"));
-        assert_eq!(get_string_by_field(&re, &text, &Both(3, 5)), Some(""));
-        assert_eq!(get_string_by_field(&re, &text, &Both(4, 5)), None);
+        assert_eq!(get_string_by_field(&re, &text, &Both(1, 1)), Some("a"));
+        assert_eq!(get_string_by_field(&re, &text, &Both(1, 2)), Some("a,b"));
+        assert_eq!(get_string_by_field(&re, &text, &Both(1, 3)), Some("a,b,c"));
+        assert_eq!(get_string_by_field(&re, &text, &Both(1, 4)), Some("a,b,c,"));
+        assert_eq!(get_string_by_field(&re, &text, &Both(1, 5)), Some("a,b,c,"));
+        assert_eq!(get_string_by_field(&re, &text, &Both(2, 5)), Some("b,c,"));
+        assert_eq!(get_string_by_field(&re, &text, &Both(3, 5)), Some("c,"));
+        assert_eq!(get_string_by_field(&re, &text, &Both(4, 5)), Some(""));
         assert_eq!(get_string_by_field(&re, &text, &Both(5, 5)), None);
         assert_eq!(get_string_by_field(&re, &text, &Both(6, 5)), None);
-        assert_eq!(get_string_by_field(&re, &text, &Both(1, 3)), Some("b,c"));
-        assert_eq!(get_string_by_field(&re, &text, &Both(2, 3)), Some("c"));
-        assert_eq!(get_string_by_field(&re, &text, &Both(3, 3)), None);
+        assert_eq!(get_string_by_field(&re, &text, &Both(2, 3)), Some("b,c"));
+        assert_eq!(get_string_by_field(&re, &text, &Both(3, 3)), Some("c"));
         assert_eq!(get_string_by_field(&re, &text, &Both(4, 3)), None);
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -11,7 +11,7 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use field::{parse_range, FieldRange};
+use field::FieldRange;
 use options::SkimOptions;
 use regex::Regex;
 use sender::CachedSender;
@@ -52,14 +52,14 @@ impl ReaderOption {
         if let Some(transform_fields) = options.with_nth {
             self.transform_fields = transform_fields
                 .split(',')
-                .filter_map(|string| parse_range(string))
+                .filter_map(|string| FieldRange::from_str(string))
                 .collect();
         }
 
         if let Some(matching_fields) = options.nth {
             self.matching_fields = matching_fields
                 .split(',')
-                .filter_map(|string| parse_range(string))
+                .filter_map(|string| FieldRange::from_str(string))
                 .collect();
         }
 


### PR DESCRIPTION
At early days of skim, the git style of field syntax (`1..3` -> [2, 3]) is chosen because I think it is a good choice for programmers.

Later I decided to take advantage of fzf's various good scripts. It was then that I tried to make skim a drop replacement of fzf. Field syntax may be the last one that was incompatible.