### PR TITLE
[curses] better cursor position sequence parsing

### DIFF
--- a/src/curses.rs
+++ b/src/curses.rs
@@ -574,11 +574,19 @@ impl Curses {
                 break;
             }
         }
-        let s = String::from_utf8(read_chars).expect("curses:get_cursor_pos: invalid utf8 string read");
-        let t: Vec<&str> = s[2..s.len() - 1].split(';').collect();
+        let seq = String::from_utf8(read_chars).expect("curses:get_cursor_pos: invalid utf8 string read");
+        let beg = seq.rfind('[').expect("curses:get_cursor_pos: invalid control sequence");
+        let coords: Vec<&str> = seq[(beg + 1)..seq.len() - 1].split(';').collect();
+
         stdout.flush().expect("curses:get_cursor_pos: failed to flush stdout");
-        let y = t[0].parse::<u16>().expect("curses:get_cursor_pos: invalid position y");
-        let x = t[1].parse::<u16>().expect("curses:get_cursor_pos: invalid position x");
+
+        let y = coords[0]
+            .parse::<u16>()
+            .expect("curses:get_cursor_pos: invalid position y");
+        let x = coords[1]
+            .parse::<u16>()
+            .expect("curses:get_cursor_pos: invalid position x");
+
         (y - 1, x - 1)
     }
 


### PR DESCRIPTION
It is possible that control sequence would have some other characters
before the real terminal response. Think, for example, about stdin chars
in buffer that were not consumed yet. That means that stripping 2 chars out
might lead to undefined behaviour.

This commit finds position of `[` symbol and gets `x` and `y` after it.