### PR TITLE
Consistent --nth and --with-nth numbering

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -27,7 +27,7 @@ pub struct Item {
     index: (usize, usize),
 
     // The text that will be ouptut when user press `enter`
-    output_text: String,
+    orig_text: String,
 
     // The text that will shown into the screen. Can be transformed.
     text: String,
@@ -83,7 +83,7 @@ impl<'a> Item {
 
         let mut ret = Item {
             index: index,
-            output_text: orig_text,
+            orig_text: orig_text,
             text: text,
             chars: Vec::new(),
             ansi_states: states_text,
@@ -111,21 +111,25 @@ impl<'a> Item {
 
     pub fn get_text(&self) -> &str {
         if !self.using_transform_fields && !self.ansi_enabled {
-            &self.output_text
+            &self.orig_text
         } else {
             &self.text
         }
     }
 
+    pub fn get_orig_text(&'a self) -> Cow<'a, str> {
+        Cow::Borrowed(&self.orig_text)
+    }
+
     pub fn get_output_text(&'a self) -> Cow<'a, str> {
         if self.using_transform_fields && self.ansi_enabled {
             let mut ansi_parser: ANSIParser = Default::default();
-            let (text, _) = ansi_parser.parse_ansi(&self.output_text);
+            let (text, _) = ansi_parser.parse_ansi(&self.orig_text);
             Cow::Owned(text)
         } else if !self.using_transform_fields && self.ansi_enabled {
             Cow::Borrowed(&self.text)
         } else {
-            Cow::Borrowed(&self.output_text)
+            Cow::Borrowed(&self.orig_text)
         }
     }
 
@@ -154,7 +158,7 @@ impl Clone for Item {
     fn clone(&self) -> Item {
         Item {
             index: self.index,
-            output_text: self.output_text.clone(),
+            orig_text: self.orig_text.clone(),
             text: self.text.clone(),
             chars: self.chars.clone(),
             ansi_states: self.ansi_states.clone(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -633,10 +633,10 @@ impl Model {
                 .get(current_idx)
                 .expect(format!("model:draw_items: failed to get item at {}", current_idx).as_str()),
         );
-        let highlighted_content = item.item.get_text();
+        let highlighted_content = item.item.get_orig_text();
 
         debug!("model:draw_preview: highlighted_content: '{:?}'", highlighted_content);
-        let cmd = self.inject_preview_command(highlighted_content);
+        let cmd = self.inject_preview_command(&highlighted_content);
         debug!("model:draw_preview: cmd: '{:?}'", cmd);
 
         let output = match get_command_output(&cmd, lines, cols) {


### PR DESCRIPTION
nth and with-nth numbering should represent the same items.

example line:  field1 field2 field3 field4
Previously with-nth=3.. and nth=1 skim would ouput field3.
Now with-nth=3.. and nth=1 skim would ouput field1. The common use case for this pattern is that field1 would represent
some identifiers that we don't want displayed but used to easily identify the selected line.

