### PR TITLE
[RFC] run preview command in other thread

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -25,7 +25,7 @@ impl Default for ANSIParser {
 }
 
 #[derive(Clone, Debug)]
-// named like to not clash with ANSIString from ansi_term crate
+// named like this not clash with ANSIString from ansi_term crate
 pub struct AnsiString {
     pub stripped: String,
     pub ansi_states: Vec<(usize, attr_t)>,

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -64,6 +64,10 @@ impl AnsiString {
     pub fn has_attrs(&self) -> bool {
         self.ansi_states.len() != 0
     }
+
+    pub fn from_str(raw: &str) -> AnsiString {
+        ANSIParser::default().parse_ansi(raw)
+    }
 }
 
 pub struct AnsiStringIterator<'a> {

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -23,8 +23,28 @@ impl Default for ANSIParser {
     }
 }
 
+#[derive(Clone, Debug)]
+// named like to not clash with ANSIString from ansi_term crate
+pub struct AnsiString {
+    pub stripped: String,
+    pub ansi_states: Vec<(usize, attr_t)>
+}
+
+impl AnsiString{
+    pub fn new_empty() -> AnsiString {
+        AnsiString {
+            stripped: "".to_string(),
+            ansi_states: Vec::new()
+        }
+    }
+
+    pub fn inner(self) -> String{
+        self.stripped
+    }
+}
+
 impl ANSIParser {
-    pub fn parse_ansi(&mut self, text: &str) -> (String, Vec<(usize, attr_t)>) {
+    pub fn parse_ansi(&mut self, text: &str) -> AnsiString {
         let mut strip_string = String::new();
         let mut colors = Vec::new();
 
@@ -58,7 +78,10 @@ impl ANSIParser {
 
         strip_string.push_str(&text[last..text.len()]);
 
-        (strip_string, colors)
+        AnsiString{
+            stripped: strip_string,
+            ansi_states: colors
+        }
     }
 
     fn interpret_code(&self, code: &str) -> Option<attr_t> {

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,6 +1,6 @@
 // Parse ANSI attr code
 
-use curses::{attr_t, register_ansi};
+use curses::{attr_t, register_ansi, Window};
 use regex::Regex;
 use std::default::Default;
 
@@ -38,8 +38,26 @@ impl AnsiString{
         }
     }
 
-    pub fn inner(self) -> String{
+    pub fn into_inner(self) -> String{
         self.stripped
+    }
+
+    pub fn print(&self, curses: &mut Window) {
+        let mut ansi_states = self.ansi_states.iter().peekable();
+        for (ch_idx, ch) in self.stripped.chars().enumerate() {
+            // print ansi color codes.
+            while let Some(&&(ansi_idx, attr)) = ansi_states.peek() {
+                if ch_idx == ansi_idx {
+                    curses.attr_on(attr);
+                    let _ = ansi_states.next();
+                } else if ch_idx > ansi_idx {
+                    let _ = ansi_states.next();
+                } else {
+                    break;
+                }
+            }
+            curses.addch(ch);
+        }
     }
 }
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -224,3 +224,18 @@ impl ANSIParser {
         //Some(attr)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ansi_iterator() {
+        let input = "\x1B[48;2;5;10;15m\x1B[38;2;70;130;180mhi\x1B[0m";
+        let ansistring = ANSIParser::default().parse_ansi(input);
+        let mut it = ansistring.iter();
+        let arr: Vec<(usize, u16)> = vec![(0, 11), (0, 12)];
+        assert_eq!(Some(('h', &arr[..2])), it.next());
+        assert_eq!(Some(('i', &arr[..0])), it.next());
+    }
+}

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -32,6 +32,7 @@ pub struct AnsiString {
 }
 
 impl AnsiString {
+
     pub fn new_empty() -> AnsiString {
         AnsiString {
             stripped: "".to_string(),
@@ -58,6 +59,10 @@ impl AnsiString {
             it_text: Box::new(self.stripped.chars().enumerate()),
             pk_ansi_states: self.ansi_states.iter().enumerate().peekable(),
         }
+    }
+
+    pub fn has_attrs(&self) -> bool {
+        self.ansi_states.len() != 0
     }
 }
 

--- a/src/curses.rs
+++ b/src/curses.rs
@@ -31,6 +31,7 @@ pub static COLOR_HEADER: u16 = 9;
 pub static COLOR_BORDER: u16 = 10;
 static COLOR_USER: u16 = 11;
 
+#[allow(non_camel_case_types)]
 pub type attr_t = u16;
 
 lazy_static! {

--- a/src/event.rs
+++ b/src/event.rs
@@ -19,6 +19,7 @@ pub enum Event {
     EvModelDrawQuery,
     EvModelDrawInfo,
     EvModelNewItem,
+    EvModelNewPreview,
     EvModelNotifyProcessed,
     EvModelNotifyMatcherMode,
     EvModelRestart,

--- a/src/item.rs
+++ b/src/item.rs
@@ -2,7 +2,6 @@
 // the internal states, such as selected or not
 
 use ansi::{ANSIParser, AnsiString};
-use curses::attr_t;
 use field::*;
 use regex::Regex;
 use std::borrow::Cow;

--- a/src/item.rs
+++ b/src/item.rs
@@ -122,7 +122,7 @@ impl<'a> Item {
         if self.using_transform_fields && self.ansi_enabled {
             let mut ansi_parser: ANSIParser = Default::default();
             let text = ansi_parser.parse_ansi(&self.orig_text);
-            Cow::Owned(text.inner())
+            Cow::Owned(text.into_inner())
         } else if !self.using_transform_fields && self.ansi_enabled {
             Cow::Borrowed(&self.text.stripped)
         } else {

--- a/src/item.rs
+++ b/src/item.rs
@@ -118,6 +118,10 @@ impl<'a> Item {
         Cow::Borrowed(&self.orig_text)
     }
 
+    pub fn get_text_struct(&self) -> &AnsiString {
+        &self.text
+    }
+
     pub fn get_output_text(&'a self) -> Cow<'a, str> {
         if self.using_transform_fields && self.ansi_enabled {
             let mut ansi_parser: ANSIParser = Default::default();

--- a/src/item.rs
+++ b/src/item.rs
@@ -142,10 +142,6 @@ impl<'a> Item {
         &self.chars
     }
 
-    pub fn get_ansi_states(&self) -> &Vec<(usize, attr_t)> {
-        &self.text.ansi_states
-    }
-
     pub fn get_index(&self) -> usize {
         self.index.1
     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,7 +1,7 @@
 // An item is line of text that read from `find` command or stdin together with
 // the internal states, such as selected or not
 
-use ansi::ANSIParser;
+use ansi::{ANSIParser, AnsiString};
 use curses::attr_t;
 use field::*;
 use regex::Regex;
@@ -30,13 +30,11 @@ pub struct Item {
     orig_text: String,
 
     // The text that will shown into the screen. Can be transformed.
-    text: String,
+    text: AnsiString,
 
     // cache of the lower case version of text. To improve speed
     chars: Vec<char>,
 
-    // the ansi state (color) of the text
-    ansi_states: Vec<(usize, attr_t)>,
     matching_ranges: Vec<(usize, usize)>,
 
     // For the transformed ANSI case, the output will need another transform.
@@ -67,18 +65,18 @@ impl<'a> Item {
 
         let mut ansi_parser: ANSIParser = Default::default();
 
-        let (text, ansi_states) = if using_transform_fields && ansi_enabled {
+        let text = if using_transform_fields && ansi_enabled {
             // ansi and transform
             ansi_parser.parse_ansi(&parse_transform_fields(delimiter, &orig_text, trans_fields))
         } else if using_transform_fields {
             // transformed, not ansi
-            (parse_transform_fields(delimiter, &orig_text, trans_fields), Vec::new())
+            AnsiString{stripped: parse_transform_fields(delimiter, &orig_text, trans_fields), ansi_states: Vec::new()}
         } else if ansi_enabled {
             // not transformed, ansi
             ansi_parser.parse_ansi(&orig_text)
         } else {
             // normal case
-            ("".to_string(), Vec::new())
+            AnsiString::new_empty()
         };
 
         let mut ret = Item {
@@ -86,7 +84,6 @@ impl<'a> Item {
             orig_text,
             text,
             chars: Vec::new(),
-            ansi_states,
             using_transform_fields: !trans_fields.is_empty(),
             matching_ranges: Vec::new(),
             ansi_enabled,
@@ -113,7 +110,7 @@ impl<'a> Item {
         if !self.using_transform_fields && !self.ansi_enabled {
             &self.orig_text
         } else {
-            &self.text
+            &self.text.stripped
         }
     }
 
@@ -124,10 +121,10 @@ impl<'a> Item {
     pub fn get_output_text(&'a self) -> Cow<'a, str> {
         if self.using_transform_fields && self.ansi_enabled {
             let mut ansi_parser: ANSIParser = Default::default();
-            let (text, _) = ansi_parser.parse_ansi(&self.orig_text);
-            Cow::Owned(text)
+            let text = ansi_parser.parse_ansi(&self.orig_text);
+            Cow::Owned(text.inner())
         } else if !self.using_transform_fields && self.ansi_enabled {
-            Cow::Borrowed(&self.text)
+            Cow::Borrowed(&self.text.stripped)
         } else {
             Cow::Borrowed(&self.orig_text)
         }
@@ -138,7 +135,7 @@ impl<'a> Item {
     }
 
     pub fn get_ansi_states(&self) -> &Vec<(usize, attr_t)> {
-        &self.ansi_states
+        &self.text.ansi_states
     }
 
     pub fn get_index(&self) -> usize {
@@ -161,7 +158,6 @@ impl Clone for Item {
             orig_text: self.orig_text.clone(),
             text: self.text.clone(),
             chars: self.chars.clone(),
-            ansi_states: self.ansi_states.clone(),
             using_transform_fields: self.using_transform_fields,
             matching_ranges: self.matching_ranges.clone(),
             ansi_enabled: self.ansi_enabled,

--- a/src/item.rs
+++ b/src/item.rs
@@ -118,8 +118,12 @@ impl<'a> Item {
         Cow::Borrowed(&self.orig_text)
     }
 
-    pub fn get_text_struct(&self) -> &AnsiString {
-        &self.text
+    pub fn get_text_struct(&self) -> Option<&AnsiString> {
+        if !self.using_transform_fields && !self.ansi_enabled {
+            None
+        } else {
+            Some(&self.text)
+        }
     }
 
     pub fn get_output_text(&'a self) -> Cow<'a, str> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ Usage: sk [options]
     --ansi               parse ANSI color codes for input strings
     --tabstop=SPACES     Number of spaces for a tab character (default: 8)
     --inline-info        Display info next to query
+    --header=STR         Display STR next to info
 
   Preview
     --preview=COMMAND    command to preview current highlighted line ({})
@@ -87,7 +88,6 @@ Usage: sk [options]
     --filepath-word
     --jump-labels=CHARS
     --border
-    --header=STR
     --header-lines=N
     --no-bold
     --history=FILE

--- a/src/model.rs
+++ b/src/model.rs
@@ -844,6 +844,7 @@ impl Model {
 
     fn act_redraw_items_and_status(&mut self, curses: &mut Curses) {
         curses.win_main.hide_cursor();
+        self.update_size(&mut curses.win_main);
         self.draw_preview(&mut curses.win_preview);
         self.draw_items(&mut curses.win_main);
         self.draw_status(&mut curses.win_main);

--- a/src/model.rs
+++ b/src/model.rs
@@ -55,7 +55,7 @@ pub struct Model {
     preview_hidden: bool,
     headers: Vec<AnsiString>,
 
-    otx_preview: Option<Sender<(Event, PreviewInput)>>,
+    tx_preview: Option<Sender<(Event, PreviewInput)>>,
 
     // Options
     multi_selection: bool,
@@ -95,7 +95,7 @@ impl Model {
             preview_hidden: true,
             headers: Vec::new(),
 
-            otx_preview: None,
+            tx_preview: None,
 
             multi_selection: false,
             reverse: false,
@@ -274,7 +274,7 @@ impl Model {
                         break;
                     }
                     Event::EvActAbort => {
-                        if let Some(tx_preview) = &self.otx_preview{
+                        if let Some(tx_preview) = &self.tx_preview{
                             tx_preview.send((Event::EvActAbort,
                                              PreviewInput{cmd: "".into(), lines: 0, columns:0}))
                                 .expect("Failed to send to tx_preview");
@@ -674,7 +674,7 @@ impl Model {
     }
 
     pub fn set_previewer(&mut self, tx_preview: Sender<(Event, PreviewInput)>){
-        self.otx_preview = Some(tx_preview);
+        self.tx_preview = Some(tx_preview);
     }
 
     fn draw_preview(&mut self, curses: &mut Window) {
@@ -709,7 +709,7 @@ impl Model {
         let cmd = self.inject_preview_command(&highlighted_content);
         debug!("model:draw_preview: cmd: '{:?}'", cmd);
 
-        if let Some(tx_preview) = &self.otx_preview {
+        if let Some(tx_preview) = &self.tx_preview {
             tx_preview.send((Event::EvModelNewPreview , PreviewInput{
                 cmd: cmd.to_string().clone(),
                 lines: lines,

--- a/src/model.rs
+++ b/src/model.rs
@@ -156,9 +156,13 @@ impl Model {
             self.inline_info = true;
         }
 
-        if let Some(header) = options.header {
+        match options.header{
+            None => {},
+            Some("") => {},
+            Some(header) => {
             self.reserved_height += 1;
             self.headers.push(AnsiString::from_str(header));
+            }
         }
     }
 
@@ -444,7 +448,7 @@ impl Model {
     fn get_status_position(&self, cursor_y: u16) -> (u16, u16) {
         match (self.inline_info, self.reverse){
             (false, true) => (1, 0),
-            (false, false) => (0, 0),
+            (false, false) => ({ self.height + self.reserved_height - 2 }, 0),
             (true, _) => ((cursor_y, self.query_end_x))
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -865,8 +865,8 @@ impl Model {
         self.update_size(&mut curses.win_main);
         self.draw_preview(&mut curses.win_preview);
         self.draw_items(&mut curses.win_main);
-        self.draw_status(&mut curses.win_main);
         self.draw_query(&mut curses.win_main, &print_query_func);
+        self.draw_status(&mut curses.win_main);
         self.draw_headers(&mut curses.win_main);
         curses.refresh();
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,4 @@
-use ansi::{ANSIParser, AnsiString};
+use ansi::AnsiString;
 use curses::*;
 use event::{Event, EventReceiver};
 use field::get_string_by_range;
@@ -10,7 +10,6 @@ use std::borrow::Cow;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::convert::From;
-use std::default::Default;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -199,7 +198,7 @@ impl Model {
                     }
                     Event::EvModelNewPreview => {
                         //debug!("model:EvModelNewPreview:handle_preview_output");
-                        let preview_output = *arg.downcast::<String>()
+                        let preview_output = *arg.downcast::<AnsiString>()
                             .expect("model:EvModelNewPreview: failed to get argument");
                         self.handle_preview_output(&mut curses.win_preview, preview_output);
                     }
@@ -712,21 +711,12 @@ impl Model {
         }
     }
 
-    fn handle_preview_output(&mut self, curses: &mut Window, output: String){
+    fn handle_preview_output(&mut self, curses: &mut Window, aoutput: AnsiString){
 
-        debug!("model:draw_preview: output: '{:?}'", output);
-
-        let mut ansi_parser: ANSIParser = Default::default();
-        let prevout = ansi_parser.parse_ansi(&output);
-
-        debug!("model:draw_preview: output = {:?}", &output);
-        debug!(
-            "model:draw_preview: {:?}",
-            prevout
-        );
+        debug!("model:draw_preview: output = {:?}", &aoutput);
 
         curses.mv(0, 0);
-        prevout.print(curses);
+        aoutput.print(curses);
         curses.attr_on(0);
 
         curses.clrtoend();

--- a/src/model.rs
+++ b/src/model.rs
@@ -570,25 +570,17 @@ impl Model {
             curses.attr_on(COLOR_CURRENT);
         }
 
-        let mut ansi_states = item.get_ansi_states().iter().peekable();
-        for (ch_idx, &ch) in text.iter().enumerate() {
-            // print ansi color codes.
-            while let Some(&&(ansi_idx, attr)) = ansi_states.peek() {
-                if ch_idx == ansi_idx {
-                    if is_current && ansi_contains_reset(attr) {
-                        curses.attr_on(COLOR_CURRENT);
-                    } else {
-                        curses.attr_on(attr);
-                    }
-                    let _ = ansi_states.next();
-                } else if ch_idx > ansi_idx {
-                    let _ = ansi_states.next();
+        for (ch, attrs) in item.get_text_struct().iter(){
+            for attr in attrs{
+                if is_current && ansi_contains_reset(attr) {
+                    curses.attr_on(COLOR_CURRENT);
                 } else {
-                    break;
+                    curses.attr_on(attr);
                 }
             }
             printer.print_char(curses, ch, COLOR_NORMAL, false, false);
         }
+
         curses.attr_on(0);
         curses.clrtoeol();
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -160,8 +160,8 @@ impl Model {
             None => {},
             Some("") => {},
             Some(header) => {
-            self.reserved_height += 1;
-            self.headers.push(AnsiString::from_str(header));
+                self.reserved_height += 1;
+                self.headers.push(AnsiString::from_str(header));
             }
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -26,7 +26,7 @@ const SPINNERS: [char; 8] = ['-', '\\', '|', '/', '-', '\\', '|', '/'];
 const DELIMITER_STR: &'static str = r"[\t\n ]+";
 
 lazy_static! {
-    static ref RE_FILEDS: Regex = Regex::new(r"\\?(\{-?[0-9.,q]*?})").unwrap();
+    static ref RE_FIELDS: Regex = Regex::new(r"\\?(\{-?[0-9.,q]*?})").unwrap();
     static ref REFRESH_DURATION: Duration = Duration::from_millis(200);
 }
 
@@ -350,7 +350,7 @@ impl Model {
                         //debug!("model:EvActRedraw:act_redraw");
                         let print_query_func = *arg.downcast::<QueryPrintClosure>()
                             .expect("model:EvActRedraw: failed to get argument");
-                        self.act_redarw(&mut curses, print_query_func);
+                        self.act_redraw(&mut curses, print_query_func);
                     }
                     _ => {}
                 }
@@ -552,7 +552,7 @@ impl Model {
         let (shift, full_width) = reshape_string(&text, self.width as usize, match_start, match_end, self.tabstop);
 
         debug!(
-            "model:draw_item: shfit: {:?}, width:{:?}, full_width: {:?}",
+            "model:draw_item: shift: {:?}, width:{:?}, full_width: {:?}",
             shift, self.width, full_width
         );
         let mut printer = LinePrinter::builder()
@@ -709,7 +709,7 @@ impl Model {
             .as_ref()
             .expect("model:inject_preview_command: invalid preview command");
         debug!("replace: {:?}, text: {:?}", cmd, text);
-        RE_FILEDS.replace_all(cmd, |caps: &Captures| {
+        RE_FIELDS.replace_all(cmd, |caps: &Captures| {
             // \{...
             if &caps[0][0..1] == "\\" {
                 return caps[0].to_string();
@@ -832,7 +832,7 @@ impl Model {
         self.hscroll_offset = hscroll_offset as usize;
     }
 
-    pub fn act_redarw(&mut self, curses: &mut Curses, print_query_func: QueryPrintClosure) {
+    pub fn act_redraw(&mut self, curses: &mut Curses, print_query_func: QueryPrintClosure) {
         curses.resize();
         self.update_size(&mut curses.win_main);
         self.draw_preview(&mut curses.win_preview);

--- a/src/model.rs
+++ b/src/model.rs
@@ -436,11 +436,13 @@ impl Model {
         res as u16
     }
 
-    fn get_status_height(&self) -> u16 {
-        if self.reverse {
-            1
+    fn get_status_position(&self, cursor_y: u16) -> (u16, u16) {
+
+        if ! self.inline_info {
+            (if self.reverse { 1 } else { self.height + self.reserved_height - 2 }
+             , 0)
         } else {
-            self.height + self.reserved_height - 2
+            ((cursor_y, self.query_end_x))
         }
     }
 
@@ -448,18 +450,13 @@ impl Model {
         // cursor should be placed on query, so store cursor before printing
         let (y, x) = curses.getyx();
 
-        let status_y = if ! self.inline_info {
-            curses.mv(self.get_status_height(), 0);
-            curses.clrtoeol();
-            self.get_status_height()
-        } else {
-            if self.query_end_x == 0 {
-                return;
-            }
-            curses.mv(y, self.query_end_x);
-            curses.clrtoeol();
+        let (status_y, status_x) = self.get_status_position(y);
+
+        curses.mv(status_y, status_x);
+        curses.clrtoeol();
+
+        if self.inline_info{
             curses.cprint("  <", COLOR_PROMPT, false);
-            y
         };
 
         // display spinner

--- a/src/model.rs
+++ b/src/model.rs
@@ -674,18 +674,18 @@ impl Model {
         debug!("model:draw_preview: output: '{:?}'", output);
 
         let mut ansi_parser: ANSIParser = Default::default();
-        let (strip_string, ansi_states) = ansi_parser.parse_ansi(&output);
+        let prevout = ansi_parser.parse_ansi(&output);
 
         debug!("model:draw_preview: output = {:?}", &output);
         debug!(
-            "model:draw_preview: strip_string: {:?}\nansi_states: {:?}",
-            strip_string, ansi_states
+            "model:draw_preview: {:?}",
+            prevout
         );
 
-        let mut ansi_states = ansi_states.iter().peekable();
+        let mut ansi_states = prevout.ansi_states.iter().peekable();
 
         curses.mv(0, 0);
-        for (ch_idx, ch) in strip_string.chars().enumerate() {
+        for (ch_idx, ch) in prevout.stripped.chars().enumerate() {
             // print ansi color codes.
             while let Some(&&(ansi_idx, attr)) = ansi_states.peek() {
                 if ch_idx == ansi_idx {

--- a/src/model.rs
+++ b/src/model.rs
@@ -571,11 +571,11 @@ impl Model {
         }
 
         for (ch, attrs) in item.get_text_struct().iter(){
-            for attr in attrs{
-                if is_current && ansi_contains_reset(attr) {
+            for (_, attr) in attrs {
+                if is_current && ansi_contains_reset(*attr) {
                     curses.attr_on(COLOR_CURRENT);
                 } else {
-                    curses.attr_on(attr);
+                    curses.attr_on(*attr);
                 }
             }
             printer.print_char(curses, ch, COLOR_NORMAL, false, false);

--- a/src/model.rs
+++ b/src/model.rs
@@ -682,23 +682,8 @@ impl Model {
             prevout
         );
 
-        let mut ansi_states = prevout.ansi_states.iter().peekable();
-
         curses.mv(0, 0);
-        for (ch_idx, ch) in prevout.stripped.chars().enumerate() {
-            // print ansi color codes.
-            while let Some(&&(ansi_idx, attr)) = ansi_states.peek() {
-                if ch_idx == ansi_idx {
-                    curses.attr_on(attr);
-                    let _ = ansi_states.next();
-                } else if ch_idx > ansi_idx {
-                    let _ = ansi_states.next();
-                } else {
-                    break;
-                }
-            }
-            curses.addch(ch);
-        }
+        prevout.print(curses);
         curses.attr_on(0);
 
         curses.clrtoend();

--- a/src/model.rs
+++ b/src/model.rs
@@ -529,6 +529,11 @@ impl Model {
         // cursor should be placed on query, so store cursor before printing
         let (y, x) = curses.getyx();
         let (maxy, _) = curses.get_maxyx();
+        let (has_headers, yh) = (self.headers.len() > 0, self.get_header_height( y, maxy));
+        if ! has_headers || yh.is_none() {
+            return;
+        }
+        let yh = yh.unwrap();
         let direction = if self.reverse {1} else {-1};
 
         let mut printer = LinePrinter::builder()
@@ -537,20 +542,18 @@ impl Model {
             .hscroll_offset(self.hscroll_offset)
             .build();
 
-        if let (true, Some(yh)) = (self.headers.len() > 0, self.get_header_height( y, maxy)) {
-            for (i, header) in self.headers.iter().enumerate(){
-                let nyh = ((yh as i64)+(direction*(i as i64))) as u16;
-                curses.mv(nyh, 0);
-                curses.clrtoeol();
-                curses.mv(nyh, 2);
-                for (ch, attrs) in header.iter(){
-                    for (_, attr) in attrs {
-                            curses.attr_on(*attr);
-                    }
-                    printer.print_char(curses, ch, COLOR_NORMAL, false, false);
+        for (i, header) in self.headers.iter().enumerate() {
+            let nyh = ((yh as i64)+(direction*(i as i64))) as u16;
+            curses.mv(nyh, 0);
+            curses.clrtoeol();
+            curses.mv(nyh, 2);
+            for (ch, attrs) in header.iter(){
+                for (_, attr) in attrs {
+                    curses.attr_on(*attr);
                 }
-
+                printer.print_char(curses, ch, COLOR_NORMAL, false, false);
             }
+
         }
         // restore cursor
         curses.mv(y, x);

--- a/src/model.rs
+++ b/src/model.rs
@@ -570,17 +570,22 @@ impl Model {
             curses.attr_on(COLOR_CURRENT);
         }
 
-        for (ch, attrs) in item.get_text_struct().iter(){
-            for (_, attr) in attrs {
-                if is_current && ansi_contains_reset(*attr) {
-                    curses.attr_on(COLOR_CURRENT);
-                } else {
-                    curses.attr_on(*attr);
+        if item.get_text_struct().is_some() && item.get_text_struct().as_ref().unwrap().has_attrs() {
+            for (ch, attrs) in item.get_text_struct().as_ref().unwrap().iter(){
+                for (_, attr) in attrs {
+                    if is_current && ansi_contains_reset(*attr) {
+                        curses.attr_on(COLOR_CURRENT);
+                    } else {
+                        curses.attr_on(*attr);
+                    }
                 }
+                printer.print_char(curses, ch, COLOR_NORMAL, false, false);
             }
-            printer.print_char(curses, ch, COLOR_NORMAL, false, false);
+        } else {
+            for ch in item.get_orig_text().chars(){
+                printer.print_char(curses, ch, COLOR_NORMAL, false, false);
+            }
         }
-
         curses.attr_on(0);
         curses.clrtoeol();
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -34,7 +34,8 @@ pub struct SkimOptions<'a> {
     pub print_query: bool,
     pub print_cmd: bool,
     pub no_hscroll: bool,
-    pub inline_info: bool
+    pub inline_info: bool,
+    pub header: Option<&'a str>,
 }
 
 impl<'a> SkimOptions<'a> {
@@ -85,6 +86,7 @@ impl<'a> SkimOptions<'a> {
         let exact = options.is_present("exact");
         let regex = options.is_present("regex");
         let inline_info = options.is_present("inline-info");
+        let header = options.values_of("header").and_then(|vals| vals.last());
 
         SkimOptions {
             color,
@@ -118,7 +120,8 @@ impl<'a> SkimOptions<'a> {
             tac,
             exact,
             regex,
-            inline_info
+            inline_info,
+            header,
         }
     }
 
@@ -266,6 +269,11 @@ impl<'a> SkimOptions<'a> {
     pub fn inline_info(self, inline_info: bool) -> Self {
         Self { inline_info, ..self }
     }
+    pub fn header(self, header: &'a str) -> Self {
+        Self { header: Some(header),
+               ..self
+        }
+    }
 }
 
 impl<'a> Default for SkimOptions<'a> {
@@ -302,7 +310,8 @@ impl<'a> Default for SkimOptions<'a> {
             print_query: false,
             print_cmd: false,
             no_hscroll: false,
-            inline_info: false
+            inline_info: false,
+            header: None
         }
     }
 }

--- a/src/previewer.rs
+++ b/src/previewer.rs
@@ -1,4 +1,5 @@
 use event::{Event, EventSender};
+use ansi::AnsiString;
 use libc;
 
 use std::env;
@@ -107,8 +108,9 @@ fn wait_and_send(mut spawned: std::process::Child, tx_model: EventSender, stoppe
     pipe.read_to_end(&mut res).expect("Failed to read from std pipe");
     let stdout = String::from_utf8_lossy(&res).to_string();
     if stdout != "" {
+        let astdout = AnsiString::from_str(&stdout);
         tx_model
-            .send((Event::EvModelNewPreview, Box::new(stdout)))
+            .send((Event::EvModelNewPreview, Box::new(astdout)))
             .expect("Failed to send Preview msg");
     }
 }

--- a/src/previewer.rs
+++ b/src/previewer.rs
@@ -1,0 +1,114 @@
+use event::{Event, EventSender};
+use libc;
+
+use std::env;
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Receiver;
+use std::sync::Arc;
+use std::thread;
+
+pub struct PreviewInput {
+    pub cmd: String,
+    pub lines: u16,
+    pub columns: u16,
+}
+
+struct PreviewThread {
+    pid: u32,
+    thread: thread::JoinHandle<()>,
+    stopped: Arc<AtomicBool>,
+}
+
+impl PreviewThread {
+    fn kill(self) {
+        if self.stopped.load(Ordering::Relaxed) == false {
+            unsafe { libc::kill(self.pid as i32, libc::SIGKILL) };
+        }
+        self.thread.join().expect("Failed to join Preview process");
+    }
+}
+
+pub fn run(rx_preview: Receiver<(Event, PreviewInput)>, tx_model: EventSender) {
+    let mut preview_thread: Option<PreviewThread> = None;
+    while let Ok((_ev, mut new_prv)) = rx_preview.recv() {
+        if preview_thread.is_some() {
+            preview_thread.unwrap().kill();
+            preview_thread = None;
+        }
+
+        if _ev == Event::EvActAbort {
+            return ();
+        }
+
+        // Try to empty the channel. Happens when spamming up/down or typing fast.
+        while let Ok((_ev, new_prv1)) = rx_preview.try_recv() {
+            if _ev == Event::EvActAbort {
+                return ();
+            }
+            new_prv = new_prv1;
+        }
+
+        let cmd = &new_prv.cmd;
+        if cmd == "" {
+            continue;
+        }
+
+        let shell = env::var("SHELL").unwrap_or("sh".to_string());
+        let spawned = Command::new(shell)
+            .env("LINES", new_prv.lines.to_string())
+            .env("COLUMNS", new_prv.columns.to_string())
+            .arg("-c")
+            .arg(&cmd)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn();
+
+        match spawned {
+            Err(err) => {
+                tx_model
+                    .clone()
+                    .send((
+                        Event::EvModelNewPreview,
+                        Box::new(format!("Failed to spawn: {} / {}", cmd, err)),
+                    ))
+                    .expect("Failed to send Error msg");
+                preview_thread = None;
+            }
+            Ok(spawned) => {
+                let pid = spawned.id();
+                let stopped = Arc::new(AtomicBool::new(false));
+                let tx_model = tx_model.clone();
+                let stopped_c = stopped.clone();
+                let thread = thread::spawn(move || wait_and_send(spawned, tx_model, stopped_c));
+                preview_thread = Some(PreviewThread { pid, thread, stopped });
+            }
+        }
+    }
+}
+
+fn wait_and_send(mut spawned: std::process::Child, tx_model: EventSender, stopped: Arc<AtomicBool>) {
+    let status = spawned.wait();
+    stopped.store(true, Ordering::SeqCst);
+
+    if status.is_err() {
+        return ();
+    }
+    let status = status.unwrap();
+
+    // Capture stderr in case users want to debug ...
+    let mut pipe: Box<Read> = if status.success() {
+        Box::new(spawned.stdout.unwrap())
+    } else {
+        Box::new(spawned.stderr.unwrap())
+    };
+    let mut res: Vec<u8> = Vec::new();
+    pipe.read_to_end(&mut res).expect("Failed to read from std pipe");
+    let stdout = String::from_utf8_lossy(&res).to_string();
+    if stdout != "" {
+        tx_model
+            .send((Event::EvModelNewPreview, Box::new(stdout)))
+            .expect("Failed to send Preview msg");
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,5 @@
 use curses::*;
-use model::ClosureType;
+use model::QueryPrintClosure;
 use options::SkimOptions;
 use std::mem;
 
@@ -131,7 +131,7 @@ impl Query {
         }
     }
 
-    pub fn get_print_func(&self) -> ClosureType {
+    pub fn get_print_func(&self) -> QueryPrintClosure {
         let before = self.get_before();
         let after = self.get_after();
         let mode = self.mode;
@@ -149,9 +149,11 @@ impl Query {
             }
 
             curses.printw(&before);
-            let (y, x) = curses.getyx();
+            let (cursor_y, cursor_x) = curses.getyx();
             curses.printw(&after);
-            curses.mv(y, x);
+            let (qend_y, qend_x) = curses.getyx();
+            curses.mv(cursor_y, cursor_x);
+            return (qend_y, qend_x);
         })
     }
 

--- a/test/test_skim.py
+++ b/test/test_skim.py
@@ -135,7 +135,7 @@ class Tmux(object):
         return ret.decode('utf8').split(INPUT_RECORD_SEPARATOR)
 
     def kill(self):
-        self._go("kill-window", "-t", f"{self.win}", stderr=subprocess.PIPE)
+        self._go("kill-window", "-t", f"{self.win}", stderr=subprocess.DEVNULL)
 
     def send_keys(self, *args, pane=None):
         if pane is not None:
@@ -158,8 +158,8 @@ class Tmux(object):
     def capture(self, pane = 0):
         def save_capture():
             try:
-                self._go('capture-pane', '-t', f'{self.win}.{pane}', stderr=subprocess.PIPE)
-                self._go("save-buffer", f"{Tmux.TEMPNAME}", stderr=subprocess.PIPE)
+                self._go('capture-pane', '-t', f'{self.win}.{pane}', stderr=subprocess.DEVNULL)
+                self._go("save-buffer", f"{Tmux.TEMPNAME}", stderr=subprocess.DEVNULL)
                 return True
             except subprocess.CalledProcessError as ex:
                 return False

--- a/test/test_skim.py
+++ b/test/test_skim.py
@@ -489,6 +489,13 @@ class TestSkim(TestBase):
         self.assertEqual(len(ret), 3)
         self.assertEqual((bef, ret[0], ret[1], ret[2]), ("> a ", 4, 4, 0))
 
+        # test that inline info is does not overwrite query
+        self.tmux.send_keys(f"echo -e 'a1\\nabcd2\\nabcd3\\nabcd4' | {self.sk('--inline-info')}", Key('Enter'))
+        self.tmux.send_keys("bc", Ctrl("a"), "a")
+        self.tmux.until(lambda lines: lines[-1].find(INLINE_INFO_SEP) != -1 and
+                        lines[-1].split(INLINE_INFO_SEP)[0] == "> abc ")
+        self.tmux.send_keys(Key('Enter'))
+
     def test_reserved_options(self):
         # --extended
         self.tmux.send_keys(f"echo -e 'a\\nb' | {self.sk('--extended')}", Key('Enter'))


### PR DESCRIPTION
Even relatively fast (150ms) preview process can slow ```skim``` to a crawl. This PR moves preview command polling to a separate thread so that problematic preview do not interfere with the model thread. 

rules i tried to follow:
  - only one preview process at time
  - no SIGKILL to finished process .. hence the ```AtomicBool```
  - no spawning of processes more than necessary e.g. when users fat finger on arrow keys.

Adds one call to libc (unsafe) to send signal.

Test locally with:
```--preview="sleep 1 && echo {}"```

the test case ```test_single_quote_of_preview_command``` will fail. This test actually doesn't do what it looks like: due to all quoting indirection the first ```echo``` ends up like ``` /bin/zsh -c echoX'"ABC"'X``` .. so the test pass only because the shell complains it cannot find the command ```echoX'"ABC"'X```.  We can see this by looking for echo i.e. ```any_include('echo')``` and the will still pass...
Anyway I have a fix which changes the way the script calls tmux and will push for comments when ready.
