### PR TITLE
[reader] Sanitize input

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -272,14 +272,11 @@ fn reader(
                     buffer.pop();
                 }
 
-                let content = unsafe {
-                    String::from_utf8_unchecked(
-                        mem::replace(&mut buffer, Vec::with_capacity(100)))
-                };
+                let content = String::from_utf8_lossy(&buffer);
 
                 debug!("reader:reader: create new item. index = {}", index);
                 let item = Item::new(
-                    content,
+                    content.to_string(),
                     opt.use_ansi_color,
                     &opt.transform_fields,
                     &opt.matching_fields,
@@ -304,7 +301,7 @@ fn reader(
                     }
                 }
             }
-            Err(_err) => {} // String not UTF8 or other error, skip.
+            Err(_err) => {} // other error, skip.
         }
     }
 


### PR DESCRIPTION
Feeding any non-utf8 in skim will likely crash it. No validation is done before this commit. ```read_until``` just read bytes. I guess this used to be ```read_string``` in the past.
Speedwise, ```from_utf8_lossy``` is not much different from the unchecked. So why not use it ?