### PR TITLE
Revert "[item] reudce some overhead on consuming input"

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -43,7 +43,7 @@ pub struct Item {
 
 impl<'a> Item {
     pub fn new(
-        orig_text: String,
+        orig_text: Cow<str>,
         ansi_enabled: bool,
         trans_fields: &[FieldRange],
         matching_fields: &[FieldRange],
@@ -79,9 +79,9 @@ impl<'a> Item {
         };
 
         let mut ret = Item {
-            index,
-            orig_text,
-            text,
+            index: index,
+            orig_text: orig_text.into_owned(),
+            text: text,
             chars: Vec::new(),
             using_transform_fields: !trans_fields.is_empty(),
             matching_ranges: Vec::new(),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -272,14 +272,9 @@ fn reader(
                     buffer.pop();
                 }
 
-                let content = unsafe {
-                    String::from_utf8_unchecked(
-                        mem::replace(&mut buffer, Vec::with_capacity(100)))
-                };
-
                 debug!("reader:reader: create new item. index = {}", index);
                 let item = Item::new(
-                    content,
+                    String::from_utf8_lossy(&buffer),
                     opt.use_ansi_color,
                     &opt.transform_fields,
                     &opt.matching_fields,


### PR DESCRIPTION
This reverts commit 49285dd76dc2c893f2e5ef89b17839a2ce1b0d2d.

We need to "check" utf8 to avoid panic.