### PR TITLE
fix #130: 100% CPU if window is not wide enough

### DIFF
--- a/src/curses.rs
+++ b/src/curses.rs
@@ -705,6 +705,10 @@ impl Curses {
         let height = self.bottom - self.top;
         let width = self.right - self.left;
 
+        if height < 3 || width < 4 {
+            panic!("printing area is two small with width: {}, height: {}", width, height);
+        }
+
         let preview_height = match self.preview_size {
             Margin::Fixed(x) => x,
             Margin::Percent(x) => height * x / 100,


### PR DESCRIPTION
Now it will panic if the printing size is not wide enough