### PR TITLE
fix #142: NULL character dropped with --ansi

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -36,8 +36,8 @@ impl Perform for ANSIParser {
 
     fn execute(&mut self, byte: u8) {
         match byte {
-            // put back \n \t
-            0x0A | 0x09 => self.partial_str.push(byte as char),
+            // put back \0 \r \n \t
+            0x00 | 0x0d | 0x0A | 0x09 => self.partial_str.push(byte as char),
             // ignore all others
             _ => trace!("AnsiParser:execute ignored {:?}", byte),
         }

--- a/test/test_skim.py
+++ b/test/test_skim.py
@@ -691,6 +691,13 @@ class TestSkim(TestBase):
         self.tmux.send_keys(command, Key('Enter'))
         self.tmux.until(lambda lines: lines.any_include('''X{}X'''))
 
+    def test_ansi_and_read0(self):
+        """should keep the NULL character, see #142"""
+        self.tmux.send_keys(f"echo -e 'a\\0b' | {self.sk('--ansi')}", Key('Enter'))
+        self.tmux.until(lambda lines: lines.match_count() == lines.item_count())
+        self.tmux.send_keys(Key('Enter'))
+        output = ":".join("{:02x}".format(ord(c)) for c in self.readonce())
+        self.assertTrue(output.find("61:00:62:0a") >= 0)
 
 def find_prompt(lines, interactive=False, reverse=False):
     linen = -1


### PR DESCRIPTION
after 0.6.0, vte was used for parsing ANSI codes, \0, \n, \t are
treated specially. Forgot to pick out \0.