### PR TITLE
Bump dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ path = "src/main.rs"
 
 
 [dependencies]
-nix = "0.11.0"
-regex = "0.2"
-lazy_static = "0.2.8"
+nix = "0.13.0"
+regex = "1.1.5"
+lazy_static = "1.3.0"
 shlex = "0.1.1"
 unicode-width = "0.1.4"
-log = "0.3.8"
-env_logger = "0.4.3"
+log = "0.4.6"
+env_logger = "0.6.1"
 time = "0.1.38"
 clap = "2.26.2"
 tuikit = "0.2.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,12 +100,15 @@ Usage: sk [options]
 ";
 
 fn main() {
-    use env_logger::LogBuilder;
-    use log::{LogLevelFilter, LogRecord};
+    use env_logger::Builder;
+    use env_logger::fmt::Formatter;
+    use log::{LevelFilter, Record};
+    use std::io::Write;
 
-    let format = |record: &LogRecord| {
+    let format = |buf: &mut Formatter, record: &Record| {
         let t = time::now();
-        format!(
+        writeln!(
+            buf,
             "{},{:03} - {} - {}",
             time::strftime("%Y-%m-%d %H:%M:%S", &t).expect("main: time format error"),
             t.tm_nsec / 1_000_000,
@@ -114,14 +117,14 @@ fn main() {
         )
     };
 
-    let mut builder = LogBuilder::new();
-    builder.format(format).filter(None, LogLevelFilter::Info);
+    let mut builder = Builder::new();
+    builder.format(format).filter(None, LevelFilter::Info);
 
     if env::var("RUST_LOG").is_ok() {
-        builder.parse(&env::var("RUST_LOG").unwrap());
+        builder.parse_filters(&env::var("RUST_LOG").unwrap());
     }
 
-    builder.init().expect("failed to initialize logger builder");
+    builder.try_init().expect("failed to initialize logger builder");
 
     let exit_code = real_main();
     std::process::exit(exit_code);


### PR DESCRIPTION
Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

Note that you could use buf.PreciseTimestamp ( https://docs.rs/env_logger/0.6.1/env_logger/fmt/struct.PreciseTimestamp.html  ) and get rid of the time crate.