### PR TITLE
fix merging ByteRanges into Chars without conversion

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -348,8 +348,9 @@ impl AndEngine {
         let mut ranges = vec![];
         for item in items {
             match item.matched_range {
-                Some(MatchedRange::ByteRange(start, end)) => {
-                    ranges.extend(start..end);
+                Some(MatchedRange::ByteRange(..)) => {
+                    ranges.extend(
+                      item.to_chars_range().unwrap());
                 }
                 Some(MatchedRange::Chars(vec)) => {
                     ranges.extend(vec.iter());

--- a/src/item.rs
+++ b/src/item.rs
@@ -193,6 +193,18 @@ impl MatchedItem {
     pub fn build(self) -> Self {
         self
     }
+
+    pub fn to_chars_range(&self) -> Option<Vec<usize>> {
+      self.matched_range.as_ref().map(|r| match r {
+        MatchedRange::ByteRange(start, end) => {
+          self.item.orig_text[*start..*end]
+            .chars()
+            .map(|x| x as usize)
+            .collect()
+        },
+        MatchedRange::Chars(vec) => vec.clone(),
+      })
+    }
 }
 
 const ITEM_POOL_CAPACITY: usize = 1024;


### PR DESCRIPTION
Or skim will crash due to out-of-bounds access because there are more bytes than chars in a multibyte string.