### PR TITLE
[RFC] Add an action, append-and-select, which appends the current query to the input and selects it

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -21,6 +21,7 @@ pub enum Event {
     EvActAbort,
     EvActAccept,
     EvActAddChar,
+    EvActAppendAndSelect,
     EvActBackwardChar,
     EvActBackwardDeleteChar,
     EvActBackwardKillWord,
@@ -89,6 +90,7 @@ pub fn parse_action(action: &str) -> Option<Event> {
     match action {
         "abort"                =>   Some(Event::EvActAbort),
         "accept"               =>   Some(Event::EvActAccept),
+        "append-and-select"    =>   Some(Event::EvActAppendAndSelect),
         "backward-char"        =>   Some(Event::EvActBackwardChar),
         "backward-delete-char" =>   Some(Event::EvActBackwardDeleteChar),
         "backward-kill-word"   =>   Some(Event::EvActBackwardKillWord),

--- a/src/model.rs
+++ b/src/model.rs
@@ -337,7 +337,7 @@ impl Model {
             cmd_query: self.query.get_cmd_query(),
             clear_selection: ClearStrategy::DontClear,
         };
-        let mut idx = 0;
+        let mut append_idx = 0;
 
         self.reader_control = Some(self.reader.run(&env.cmd));
 
@@ -398,14 +398,13 @@ impl Model {
                             &Vec::new(),
                             &Vec::new(),
                             &Regex::new("").unwrap(),
-                            (std::usize::MAX, idx),
+                            (std::usize::MAX, append_idx),
                         );
-                        dbg!((std::usize::MAX, idx));
-                        idx = idx + 1;
-                        let arc = Arc::new(item);
-                        v.push(arc.clone());
+                        append_idx += 1;
+                        let item = Arc::new(item);
+                        v.push(item.clone());
                         self.item_pool.append(v);
-                        let mitem = MatchedItem::builder(arc).build();
+                        let mitem = MatchedItem::builder(item).build();
                         self.selection.act_toggle_item(mitem);
                         env.clear_selection = ClearStrategy::Clear;
                         self.query.act_line_discard();

--- a/src/model.rs
+++ b/src/model.rs
@@ -406,9 +406,6 @@ impl Model {
                         self.item_pool.append(v);
                         let mitem = MatchedItem::builder(item).build();
                         self.selection.act_toggle_item(mitem);
-                        env.clear_selection = ClearStrategy::Clear;
-                        self.query.act_line_discard();
-                        self.on_query_change(&mut env);
                     }
                 }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -185,6 +185,18 @@ impl Selection {
         }
     }
 
+    pub fn act_toggle_item(&mut self, mitem: MatchedItem) {
+        if !self.multi_selection {
+            return;
+        }
+        let index = mitem.item.get_full_index();
+        if !self.selected.contains_key(&index) {
+            self.selected.insert(index, mitem.clone());
+        } else {
+            self.selected.remove(&index);
+        }
+    }
+
     pub fn act_toggle_all(&mut self) {
         for current_item in self.items.iter() {
             let index = current_item.item.get_full_index();


### PR DESCRIPTION
Demo: https://asciinema.org/a/Te9lQZ5vOUV0pz4KNZlq9b4rd

I built this to use as part of interactive pipelines where I wish to add tags, like a cli bookmarking tool. It's not the cleanest implementation, but I think its a nice feature that I haven't found in any similar tools.

If the feature itself is interesting but you'd like to discuss how to clean the implementation up, I'm happy to do so.