### PR TITLE
add SKIM_CTRL_R_COMMAND env variable for zsh

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -69,7 +69,8 @@ bindkey '\ec' skim-cd-widget
 skim-history-widget() {
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail 2> /dev/null
-  selected=( $(fc -rl 1 |
+  local cmd="${SKIM_CTRL_R_COMMAND:-"fc -rl 1"}"
+  selected=( $(eval "$cmd" |
     SKIM_DEFAULT_OPTIONS="--height ${SKIM_TMUX_HEIGHT:-40%} $SKIM_DEFAULT_OPTIONS -n2..,.. --tiebreak=index $SKIM_CTRL_R_OPTS --query=${(qqq)LBUFFER} -m" $(__skimcmd)) )
   local ret=$?
   if [ -n "$selected" ]; then


### PR DESCRIPTION
It wasn't possible to set an alternative command to look up the zsh
history. With `SKIM_CTRL_R_COMMAND` it's possible to set an alternative
command like `fc -rln 1` for hiding the history IDs and therefore not
searching through those.

Signed-off-by: Christian Rebischke <chris@nullday.de>