### PR TITLE
Add installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ dnf install skim
 apk add skim
 ```
 
+### On Arch
+
+```sh
+pacman -S skim
+```
+
 ### From sources
 
 Clone this repository and run the install script:


### PR DESCRIPTION
Hello! 
I noticed someone has already made a package on the Community repository, and there are no installation instructions for Arch Linux in the README file. So I thought it might be useful to add them \(≧▽≦)/


Here is a link to the package: [archlinux.org/packages/community/x86_64/skim](https://www.archlinux.org/packages/community/x86_64/skim/)
also, there is [a git package](https://aur.archlinux.org/packages/skim-git/) on AUR.

Have a nice day!