### PR TITLE
fix #252 deal with '\b' correctly

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -37,8 +37,12 @@ impl Perform for ANSIParser {
 
     fn execute(&mut self, byte: u8) {
         match byte {
-            // put back \0 \r \n \b \t
-            0x00 | 0x0d | 0x0A | 0x08 | 0x09 => self.partial_str.push(byte as char),
+            // \b to delete character back
+            0x08 => {
+                self.partial_str.pop();
+            }
+            // put back \0 \r \n \t
+            0x00 | 0x0d | 0x0A | 0x09 => self.partial_str.push(byte as char),
             // ignore all others
             _ => trace!("AnsiParser:execute ignored {:?}", byte),
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,13 @@
-use crate::field::get_string_by_range;
-use crate::item::Item;
-use regex::{Captures, Regex};
 use std::borrow::Cow;
 use std::cmp::min;
 use std::prelude::v1::*;
+
+use regex::{Captures, Regex};
 use tuikit::prelude::*;
 use unicode_width::UnicodeWidthChar;
+
+use crate::field::get_string_by_range;
+use crate::item::Item;
 
 lazy_static! {
     static ref RE_FIELDS: Regex = Regex::new(r"\\?(\{ *-?[0-9.,cq+]*? *})").unwrap();
@@ -150,18 +152,22 @@ impl LinePrinter {
     }
 
     pub fn print_char(&mut self, canvas: &mut dyn Canvas, ch: char, attr: Attr, skip: bool) {
-        if ch != '\t' {
-            self.print_char_raw(canvas, ch, attr, skip);
-        } else {
-            // handle tabstop
-            let rest = if self.current_pos < 0 {
-                self.tabstop
-            } else {
-                self.tabstop - (self.current_pos as usize) % self.tabstop
-            };
-            for _ in 0..rest {
-                self.print_char_raw(canvas, ' ', attr, skip);
+        match ch {
+            '\u{08}' => {
+                // ignore \b character
             }
+            '\t' => {
+                // handle tabstop
+                let rest = if self.current_pos < 0 {
+                    self.tabstop
+                } else {
+                    self.tabstop - (self.current_pos as usize) % self.tabstop
+                };
+                for _ in 0..rest {
+                    self.print_char_raw(canvas, ' ', attr, skip);
+                }
+            }
+            ch => self.print_char_raw(canvas, ch, attr, skip),
         }
     }
 }


### PR DESCRIPTION
Though I'd recommend not using these tricky characters at all, here is
how it is handled in skim:

1. with `--ansi`, '\b' will delete the previous character
2. without `--ansi`, '\b' will be ignored at renderinga
    - note that the '\b' character still exists for matching