### PR TITLE
fix #210: exclude current item in multi-selection

### DIFF
--- a/src/selection.rs
+++ b/src/selection.rs
@@ -232,7 +232,8 @@ impl Selection {
 
     pub fn get_selected_items(&mut self) -> Vec<Arc<Item>> {
         // select the current one
-        if !self.items.is_empty() {
+        let select_cursor = !self.multi_selection || self.selected.is_empty();
+        if select_cursor && !self.items.is_empty() {
             let cursor = self.item_cursor + self.line_cursor;
             let current_item = self
                 .items


### PR DESCRIPTION
Be compatible to fzf:
1. If multi-selection is not enabled, select current item
2. If multi-selection is enabled
    a) No item is selected -> select current item
    b) already selected some items -> exclude current item