### PR TITLE
fix: ensure screen is rendered with item

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ mod theme;
 mod util;
 
 pub use crate::ansi::AnsiString;
-use crate::event::Event::*;
 use crate::event::{EventReceiver, EventSender};
 pub use crate::item_collector::*;
 use crate::model::Model;
@@ -129,10 +128,6 @@ impl Skim {
         // reader
 
         let reader = Reader::with_options(&options).source(source);
-
-        //------------------------------------------------------------------------------
-        // start a timer for notifying refresh
-        let _ = tx.send(EvHeartBeat);
 
         //------------------------------------------------------------------------------
         // model + previewer

--- a/src/model.rs
+++ b/src/model.rs
@@ -382,7 +382,7 @@ impl Model {
         self.reader_control = Some(self.reader.run(&env.cmd));
 
         // In the event loop, there might need
-        let mut next_event = None;
+        let mut next_event = Some(Event::EvHeartBeat);
         loop {
             let ev = next_event.take().or_else(|| self.rx.recv().ok())?;
 


### PR DESCRIPTION
Currently the first EvHeartBeat might be triggered before the reader
start. When this happens, the screen will not be updated before any
following events.