### PR TITLE
Feat asany

### DIFF
--- a/examples/custom_item.rs
+++ b/examples/custom_item.rs
@@ -10,7 +10,7 @@ struct MyItem {
 
 impl SkimItem for MyItem {
     fn display(&self) -> Cow<AnsiString> {
-        Cow::Owned(AnsiString::new_str(&self.inner))
+        Cow::Owned(self.inner.as_str().into())
     }
 
     fn get_text(&self) -> Cow<str> {

--- a/examples/custom_item.rs
+++ b/examples/custom_item.rs
@@ -1,8 +1,5 @@
 extern crate skim;
-use crossbeam::channel::unbounded;
 use skim::prelude::*;
-use std::borrow::Cow;
-use std::sync::Arc;
 
 struct MyItem {
     inner: String,
@@ -13,12 +10,16 @@ impl SkimItem for MyItem {
         Cow::Owned(self.inner.as_str().into())
     }
 
-    fn get_text(&self) -> Cow<str> {
+    fn text(&self) -> Cow<str> {
         Cow::Borrowed(&self.inner)
     }
 
     fn preview(&self) -> ItemPreview {
-        ItemPreview::Text(format!("hello, {}", self.inner))
+        if self.inner.starts_with("color") {
+            ItemPreview::AnsiText(format!("\x1b[31mhello:\x1b[m\n{}", self.inner))
+        } else {
+            ItemPreview::Text(format!("hello:\n{}", self.inner))
+        }
     }
 }
 
@@ -32,7 +33,7 @@ pub fn main() {
 
     let (tx_item, rx_item): (SkimItemSender, SkimItemReceiver) = unbounded();
     let _ = tx_item.send(Arc::new(MyItem {
-        inner: "aaaaa".to_string(),
+        inner: "color aaaa".to_string(),
     }));
     let _ = tx_item.send(Arc::new(MyItem {
         inner: "bbbb".to_string(),

--- a/examples/option_builder.rs
+++ b/examples/option_builder.rs
@@ -12,7 +12,7 @@ pub fn main() {
 
     //==================================================
     // first run
-    let input = "aaaaa\nbbbb\nccc".to_string();
+    let input = "aaaaa\nbbbb\nccc";
     let items = item_reader.of_bufread(Cursor::new(input));
     let selected_items = Skim::run_with(&options, Some(items))
         .map(|out| out.selected_items)
@@ -24,7 +24,7 @@ pub fn main() {
 
     //==================================================
     // second run
-    let input = "11111\n22222\n333333333".to_string();
+    let input = "11111\n22222\n333333333";
     let items = item_reader.of_bufread(Cursor::new(input));
     let selected_items = Skim::run_with(&options, Some(items))
         .map(|out| out.selected_items)

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -226,7 +226,7 @@ impl<'a> AnsiString<'a> {
         }
     }
 
-    pub fn new_string(string: String) -> Self {
+    fn new_string(string: String) -> Self {
         let stripped: Cow<'static, str> = Cow::Owned(string);
         Self {
             stripped: stripped.clone(),
@@ -234,7 +234,7 @@ impl<'a> AnsiString<'a> {
         }
     }
 
-    pub fn new_str(str_ref: &'a str) -> Self {
+    fn new_str(str_ref: &'a str) -> Self {
         let stripped: Cow<'a, str> = Cow::Borrowed(str_ref);
         Self {
             stripped: stripped.clone(),
@@ -242,7 +242,7 @@ impl<'a> AnsiString<'a> {
         }
     }
 
-    pub fn new(stripped: String, fragments: Vec<(Attr, Cow<'static, str>)>) -> Self {
+    fn new(stripped: String, fragments: Vec<(Attr, Cow<'static, str>)>) -> Self {
         Self {
             stripped: Cow::Owned(stripped),
             fragments,
@@ -272,6 +272,18 @@ impl<'a> AnsiString<'a> {
 
     pub fn stripped(&self) -> &str {
         &self.stripped
+    }
+}
+
+impl<'a> From<&'a str> for AnsiString<'a> {
+    fn from(s: &'a str) -> AnsiString<'a> {
+        AnsiString::new_str(s)
+    }
+}
+
+impl From<String> for AnsiString<'static> {
+    fn from(s: String) -> Self {
+        AnsiString::new_string(s)
     }
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -60,8 +60,8 @@ impl MatchEngine for RegexEngine {
                 break;
             }
 
-            matched_result = score::regex_match(&item.get_text()[start..end], &self.query_regex)
-                .map(|(s, e)| (s + start, e + start));
+            matched_result =
+                score::regex_match(&item.text()[start..end], &self.query_regex).map(|(s, e)| (s + start, e + start));
 
             if matched_result.is_some() {
                 break;
@@ -122,9 +122,9 @@ impl MatchEngine for FuzzyEngine {
         let mut matched_result = None;
         for &(start, end) in item.get_matching_ranges().as_ref() {
             matched_result =
-                score::fuzzy_match(&item.get_text()[start..end], &self.query, self.algorithm).map(|(s, vec)| {
+                score::fuzzy_match(&item.text()[start..end], &self.query, self.algorithm).map(|(s, vec)| {
                     if start != 0 {
-                        let start_char = &item.get_text()[..start].chars().count();
+                        let start_char = &item.text()[..start].chars().count();
                         (s, vec.iter().map(|x| x + start_char).collect())
                     } else {
                         (s, vec)
@@ -235,7 +235,7 @@ impl ExactEngine {
                 break;
             }
 
-            matched_result = score::exact_match(&item.get_text()[start..end], &self.query);
+            matched_result = score::exact_match(&item.text()[start..end], &self.query);
 
             if matched_result.is_some() {
                 range_start = start;

--- a/src/item.rs
+++ b/src/item.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 /// more than one line.
 #[derive(Debug)]
 pub struct DefaultSkimItem {
-    // The text that will be ouptut when user press `enter`
+    // The text that will be output when user press `enter`
     orig_text: String,
 
     // The text that will shown into the screen. Can be transformed.
@@ -65,7 +65,7 @@ impl<'a> DefaultSkimItem {
             ansi_parser.parse_ansi(&parse_transform_fields(delimiter, &orig_text, trans_fields))
         } else if using_transform_fields {
             // transformed, not ansi
-            AnsiString::new_string(parse_transform_fields(delimiter, &orig_text, trans_fields))
+            parse_transform_fields(delimiter, &orig_text, trans_fields).into()
         } else if ansi_enabled {
             // not transformed, ansi
             ansi_parser.parse_ansi(&orig_text)
@@ -98,7 +98,7 @@ impl SkimItem for DefaultSkimItem {
         if self.using_transform_fields || self.ansi_enabled {
             Cow::Borrowed(&self.text)
         } else {
-            Cow::Owned(AnsiString::new_str(&self.orig_text))
+            Cow::Owned(self.orig_text.as_str().into())
         }
     }
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -83,9 +83,9 @@ impl<'a> DefaultSkimItem {
         };
 
         let matching_ranges = if !matching_fields.is_empty() {
-            parse_matching_fields(delimiter, &ret.get_text(), matching_fields)
+            parse_matching_fields(delimiter, &ret.text(), matching_fields)
         } else {
-            vec![(0, ret.get_text().len())]
+            vec![(0, ret.text().len())]
         };
 
         ret.matching_ranges = matching_ranges;
@@ -102,7 +102,7 @@ impl SkimItem for DefaultSkimItem {
         }
     }
 
-    fn get_text(&self) -> Cow<str> {
+    fn text(&self) -> Cow<str> {
         if !self.using_transform_fields && !self.ansi_enabled {
             Cow::Borrowed(&self.orig_text)
         } else {
@@ -157,8 +157,8 @@ impl SkimItem for ItemWrapper {
         self.inner.display()
     }
 
-    fn get_text(&self) -> Cow<str> {
-        self.inner.get_text()
+    fn text(&self) -> Cow<str> {
+        self.inner.text()
     }
 
     fn output(&self) -> Cow<str> {
@@ -223,8 +223,8 @@ impl MatchedItem {
     pub fn range_char_indices(&self) -> Option<Vec<usize>> {
         self.matched_range.as_ref().map(|r| match r {
             MatchedRange::ByteRange(start, end) => {
-                let first = self.item.get_text()[..*start].chars().count();
-                let last = first + self.item.get_text()[*start..*end].chars().count();
+                let first = self.item.text()[..*start].chars().count();
+                let last = first + self.item.text()[*start..*end].chars().count();
                 (first..last).collect()
             }
             MatchedRange::Chars(vec) => vec.clone(),

--- a/src/item_collector.rs
+++ b/src/item_collector.rs
@@ -7,7 +7,7 @@ use std::env;
 use std::error::Error;
 use std::io::{BufRead, BufReader};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicUsize, Ordering, AtomicBool};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
 
@@ -116,7 +116,7 @@ pub fn read_and_collect_from_command(
         debug!("collector: command killer stop");
     });
 
-    while ! started.load(Ordering::SeqCst) {
+    while !started.load(Ordering::SeqCst) {
         // busy waiting for the thread to start. (components_to_stop is added)
     }
 
@@ -172,7 +172,7 @@ pub fn read_and_collect_from_command(
         debug!("collector: command collector stop");
     });
 
-    while ! started.load(Ordering::SeqCst) {
+    while !started.load(Ordering::SeqCst) {
         // busy waiting for the thread to start. (components_to_stop is added)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub trait SkimItem: Send + Sync {
 
 impl<T: AsRef<str> + Send + Sync> SkimItem for T {
     fn display(&self) -> Cow<AnsiString> {
-        Cow::Owned(AnsiString::new_str(self.as_ref()))
+        Cow::Owned(self.as_ref().into())
     }
 
     fn get_text(&self) -> Cow<str> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub use crate::output::SkimOutput;
 use crate::reader::Reader;
 pub use crate::score::FuzzyAlgorithm;
 use crossbeam::channel::{Receiver, Sender};
+use std::any::Any;
 use std::borrow::Cow;
 use std::env;
 use std::sync::mpsc::channel;
@@ -42,20 +43,83 @@ use std::thread;
 use tuikit::prelude::{Event as TermEvent, *};
 
 //------------------------------------------------------------------------------
-pub trait SkimItem: Send + Sync {
-    /// The text to be displayed on the item list, could contain ANSI properties
-    fn display(&self) -> Cow<AnsiString>;
-
-    /// helper function to get pure text presentation(without color) of the item
-    fn get_text(&self) -> Cow<str>;
-
-    /// get output text(after accept), could be override
-    fn output(&self) -> Cow<str> {
-        self.get_text()
+pub trait AsAny {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+impl<T: Any> AsAny for T {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// A `SkimItem` defines what's been processed(fetched, matched, previewed and returned) by skim
+///
+/// # Downcast Example
+/// Normally skim will return the item back, but in `Arc<dyn SkimItem>`. You might want a reference
+/// to the concrete type instead of trait object. Skim provide a somehow "complicated" way to
+/// `downcast` it back to the reference of the original concrete type.
+///
+/// ```rust
+/// use skim::prelude::*;
+///
+/// struct MyItem {}
+/// impl SkimItem for MyItem {
+///     fn display(&self) -> Cow<AnsiString> {
+///         unimplemented!()
+///     }
+///
+///     fn text(&self) -> Cow<str> {
+///         unimplemented!()
+///     }
+/// }
+///
+/// impl MyItem {
+///     pub fn mutable(&mut self) -> i32 {
+///         1
+///     }
+///
+///     pub fn immutable(&self) -> i32 {
+///         0
+///     }
+/// }
+///
+/// let mut ret: Arc<dyn SkimItem> = Arc::new(MyItem{});
+/// let mutable: &mut MyItem = Arc::get_mut(&mut ret)
+///     .expect("item is referenced by others")
+///     .as_any_mut() // cast to Any
+///     .downcast_mut::<MyItem>() // downcast to (mut) concrete type
+///     .expect("something wrong with downcast");
+/// assert_eq!(mutable.mutable(), 1);
+///
+/// let immutable: &MyItem = (*ret).as_any() // cast to Any
+///     .downcast_ref::<MyItem>() // downcast to concrete type
+///     .expect("something wrong with downcast");
+/// assert_eq!(immutable.immutable(), 0)
+/// ```
+pub trait SkimItem: AsAny + Send + Sync + 'static {
+    /// The content to be displayed on the item list, could contain ANSI properties
+    fn display(&self) -> Cow<AnsiString>;
+
+    /// the string to be used for matching(without color)
+    fn text(&self) -> Cow<str>;
+
+    /// Custom preview content, default to `ItemPreview::Global` which will use global preview
+    /// setting(i.e. the command set by `preview` option)
     fn preview(&self) -> ItemPreview {
         ItemPreview::Global
+    }
+
+    /// Get output text(after accept), default to `text()`
+    /// Note that this function is intended to be used by the caller of skim and will not be used by
+    /// skim. And since skim will return the item back in `SkimOutput`, if string is not what you
+    /// want, you could still use `downcast` to retain the pointer to the original struct.
+    fn output(&self) -> Cow<str> {
+        self.text()
     }
 
     /// we could limit the matching ranges of the `get_text` of the item.
@@ -65,21 +129,27 @@ pub trait SkimItem: Send + Sync {
     }
 }
 
-impl<T: AsRef<str> + Send + Sync> SkimItem for T {
+impl<T: AsRef<str> + Send + Sync + 'static> SkimItem for T {
     fn display(&self) -> Cow<AnsiString> {
         Cow::Owned(self.as_ref().into())
     }
 
-    fn get_text(&self) -> Cow<str> {
+    fn text(&self) -> Cow<str> {
         Cow::Borrowed(self.as_ref())
     }
 }
 
 //------------------------------------------------------------------------------
 // Preview
+
 pub enum ItemPreview {
+    /// execute the command and print the command's output
     Command(String),
+    /// Display the prepared text(lines)
     Text(String),
+    /// Display the colored text(lines)
+    AnsiText(String),
+    /// Use global command settings to preview the item
     Global,
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -336,7 +336,7 @@ impl Model {
         let cmd_query = self.query.get_cmd_query();
 
         let tmp = self.selection.get_selected_items();
-        let tmp: Vec<Cow<str>> = tmp.iter().map(|item| item.get_text()).collect();
+        let tmp: Vec<Cow<str>> = tmp.iter().map(|item| item.text()).collect();
         let selected_texts: Vec<&str> = tmp.iter().map(|cow| cow.as_ref()).collect();
 
         let context = InjectContext {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,4 +3,7 @@ pub use crate::item_collector::*;
 pub use crate::options::{SkimOptions, SkimOptionsBuilder};
 pub use crate::output::SkimOutput;
 pub use crate::score::FuzzyAlgorithm;
-pub use crate::{ItemPreview, Skim, SkimItem, SkimItemReceiver, SkimItemSender};
+pub use crate::{AsAny, ItemPreview, Skim, SkimItem, SkimItemReceiver, SkimItemSender};
+pub use crossbeam::channel::{bounded, unbounded, Receiver, Sender};
+pub use std::borrow::Cow;
+pub use std::sync::Arc;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -8,10 +8,9 @@ use crate::spinlock::SpinLock;
 use crate::SkimItemReceiver;
 use crossbeam::channel::{bounded, select, Sender};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread;
-use bitflags::_core::sync::atomic::AtomicBool;
 
 const CHANNEL_SIZE: usize = 1024;
 
@@ -146,7 +145,7 @@ fn collect_item(
         debug!("reader: collect_item stop");
     });
 
-    while ! started.load(Ordering::SeqCst) {
+    while !started.load(Ordering::SeqCst) {
         // busy waiting for the thread to start. (components_to_stop is added)
     }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -380,7 +380,7 @@ impl Selection {
         }
 
         let item = &matched_item.item;
-        let text = item.get_text();
+        let text = item.text();
         let (match_start_char, match_end_char) = match matched_item.matched_range {
             Some(MatchedRange::Chars(ref matched_indices)) => {
                 if !matched_indices.is_empty() {


### PR DESCRIPTION
1. add `as_any` for `SkimItem`
2. fix preview: deal with multi-lines prepared text
3. API for preview (non-)colored text

Skim will take trait object `Arc<dyn SkimItem>` and will return it back
in `SkimOutput`. Caller will need the concrete type reference to call
some type-specific methods.  The `AsAny` trait is used for downcasting
`Arc<dyn SkimItem>` back to reference to its concrete type.

Q: Why not use associated type?
A:

1. Associated type would pollute all the type signatures that deals with
   `SkimItem`. Some traits could no longer be made into trait object
   with generic type in their method signature.
   ```
    pub trait MatchEngine: Sync + Send {
        fn match_item<T: SkimItem>(&self, item: Arc<ItemWrapper<T>>) -> Option<MatchedItem<T>>;
    }
   ```
   To fix it would require much more work than I think.
2. Currently the support for "interaction mode" and "append-and-select"
   action is done inside skim. That means some items added to skim could
   not guarentee to be the associated type.
