### PR TITLE
exit on broken pipe 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,7 @@ dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuzzy-matcher 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ bitflags = "1.0.4"
 timer = "0.2.0"
 chrono = "0.4"
 crossbeam = "0.7.3"
+libc = "0.2"
 
 [features]
 default = []


### PR DESCRIPTION
Using a pipe to restrict the output of `skim -f <somestring>` results in an error:

```bash
thread 'main' panicked at 'failed printing to stdout: Broken pipe (os error 32)', src/libstd/io/stdio.rs:805:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The error is innocuous, yet should probably be addressed in a future commit. Ideally, `skim` should terminate once it encounters a `Broken Pipe` error internally. `ripgrep` has gone through this same feature progression, as documented by these links:

https://github.com/BurntSushi/ripgrep/issues/200
https://github.com/BurntSushi/ripgrep/pull/586/files

In that discussion, there is a hacky fix to terminate the program once it encounters a `SIGPIPE` error. This fix is what I have included in this PR.

Like @BurntSushi laments, this error should be handled naturally within the program. I'm not too comfortable with Rust so I wasn't able to understand how he handles in `ripgrep`, but in case anyone wants to understand it, the commit that makes this feature possible is at https://github.com/BurntSushi/ripgrep/pull/1017/files#diff-639fbc4ef05b315af92b4d836c31b023

I've tested this hotfix on my local machine and it seems to terminate as expected. Speed wise, I am not seeing any difference. 