### PR TITLE
don't add multiple time in a row the same entry in the history file

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -420,6 +420,10 @@ fn write_history_to_file(
     limit: usize,
     filename: &str,
 ) -> Result<(), std::io::Error> {
+    if orig_history.last().map(|l| l.as_str()) == Some(latest) {
+        // no point of having at the end of the history 5x the same command...
+        return Ok(());
+    }
     let additional_lines = if latest.trim().is_empty() { 0 } else { 1 };
     let start_index = if orig_history.len() + additional_lines > limit {
         orig_history.len() + additional_lines - limit


### PR DESCRIPTION
hi, i lifted your history function for my app which uses the skim library, and after a short amount of time started wondering whether the history worked, it seemed ctrl-p did not show me the previous entry.

it turned out that my history file looked like that:

aa
bb
cc
cc
cc

i don't think it's useful in a history file to repeat multiple times the same entry in a row, it just forces the user to press several times the same shortcut. So i made that change to my version of the function, I think this change also makes sense for skim itself.