### PR TITLE
Fix a trivial typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ skim project contains several components:
 
 | Distribution   | Package Manager   | Command            |
 | -------------- | ----------------- | ---------          |
-| Mac OS         | homebrew          | `brew instsall sk` |
+| Mac OS         | homebrew          | `brew install sk`  |
 | Fedora         | dnf               | `dnf install skim` |
 | Alpine         | apk               | `apk add skim`     |
 | Arch           | pacman            | `pacman -S skim`   |


### PR DESCRIPTION
Just one character though.. I've encountered this error message when I just copy&paste it

```
$ brew instsall sk
Error: Unknown command: instsall
```