### PR TITLE
fix #365: new option `--show-cmd-error`

### DIFF
--- a/man/man1/sk.1
+++ b/man/man1/sk.1
@@ -217,6 +217,13 @@ This is not default however because similar usecases for \fBgrep\fR and
 \fBrg\fR had already been optimized where empty result of a query do mean
 "empty" and previous results should be cleared.
 
+.TP
+.BI "--show-cmd-error"
+If the command fails, send the error messages and show them as items. This
+option was intended to help debugging interactive commands. It's not enabled
+by default because the command often fails before we complete the "cmd-query"
+and error messages would be annoying.
+
 .SS Display
 .TP
 .B "--ansi"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -55,6 +55,7 @@ Usage: sk [options]
     --keep-right         Keep the right end of the line visible on overflow
     --skip-to-pattern    Line starts with the start of matched pattern
     --no-clear-if-empty  Do not clear previous items if command returns empty result
+    --show-cmd-error     Send command error message if command fails
 
   Layout
     --layout=LAYOUT      Choose layout: [default|reverse|reverse-list]
@@ -238,6 +239,7 @@ fn real_main() -> Result<i32, std::io::Error> {
         .arg(Arg::with_name("pre-select-items").long("pre-select-items").multiple(true).takes_value(true))
         .arg(Arg::with_name("pre-select-file").long("pre-select-file").multiple(true).takes_value(true).default_value(""))
         .arg(Arg::with_name("no-clear-if-empty").long("no-clear-if-empty").multiple(true))
+        .arg(Arg::with_name("show-cmd-error").long("show-cmd-error").multiple(true))
         .get_matches_from(args);
 
     if opts.is_present("help") {
@@ -264,6 +266,7 @@ fn real_main() -> Result<i32, std::io::Error> {
         .with_nth(opts.values_of("with-nth").and_then(|vals| vals.last()).unwrap_or(""))
         .nth(opts.values_of("nth").and_then(|vals| vals.last()).unwrap_or(""))
         .read0(opts.is_present("read0"))
+        .show_error(opts.is_present("show-cmd-error"))
         .build();
 
     let cmd_collector = Rc::new(RefCell::new(SkimItemReader::new(item_reader_option)));

--- a/test/test_skim.py
+++ b/test/test_skim.py
@@ -895,7 +895,7 @@ class TestSkim(TestBase):
     def test_cmd_history(self):
         """query history should work"""
 
-        history_file = f'{self.tempname()}.history'
+        history_file = f'{self.tempname()}.cmd-history'
 
         self.tmux.send_keys(f"echo -e 'a\nb\nc' > {history_file}", Key('Enter'))
         self.tmux.send_keys(f"""{self.sk("-i -c 'echo {}'", '--cmd-history', history_file)}""", Key('Enter'))
@@ -1031,7 +1031,7 @@ class TestSkim(TestBase):
 
     def test_no_clear_if_empty(self):
         text_file = f'{self.tempname()}.txt'
-        self.tmux.send_keys(f"echo -e 'b\nc' > {text_file}", Key('Enter'))
+        self.tmux.send_keys(f"echo -e 'b\\nc' > {text_file}", Key('Enter'))
 
         args = "-c 'cat {}'" + f''' -i --cmd-query='{text_file}' --no-clear-if-empty'''
         self.tmux.send_keys(f"""{self.sk(args)}""", Key('Enter'))


### PR DESCRIPTION
Currently the invoked command would fail silently. Sometimes this might
not be desirable because we have no idea whether it outputs nothing or
died.

New option `--show-cmd-error` is designed to send the error message and
display them as items.

It's somehow a trade-off choice that I don't want to modify the
current library interface. Also it's not made default because there
might be several fail invocation before we complete the whole
"cmd-query".