### PR TITLE
Bash completion is for `sk`, not `skim`

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -293,7 +293,7 @@ _skim_alias_completion() {
 }
 
 # skim options
-complete -o default -F _skim_opts_completion skim
+complete -o default -F _skim_opts_completion sk
 
 d_cmds="${SKIM_COMPLETION_DIR_COMMANDS:-cd pushd rmdir}"
 a_cmds="


### PR DESCRIPTION
Currently bash completion does not work for me on Arch or MacOS. It looks like the completion file is currently set up to provide completions for the command `skim`, but that command doesn't exist on either of these platforms. Changing this line to `sk` instead of `skim` seems to properly provide tab completion for sk's options.