### PR TITLE
Update beef to prevent data races

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "beef"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474a626a67200bd107d44179bb3d4fc61891172d11696609264589be6a0e6a43"
+checksum = "6736e2428df2ca2848d846c43e88745121a6654696e349ce0054a420815a7409"
 
 [[package]]
 name = "bitflags"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ bitflags = "1.0.4"
 timer = "0.2.0"
 chrono = "0.4"
 crossbeam = "0.8.0"
-beef = "0.4.4" # compact cow
+beef = "0.5.0" # compact cow
 defer-drop = "1.0.1"
 
 [features]


### PR DESCRIPTION
Output from `cargo audit`
```
Crate:         beef
Version:       0.4.4
Title:         beef::Cow lacks a Sync bound on its Send trait allowing for data races
Date:          2020-10-28
ID:            RUSTSEC-2020-0122
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0122
Solution:      Upgrade to >=0.5.0
Dependency tree:
beef 0.4.4
└── skim 0.9.3
```