### PR TITLE
WIP - Pre-select works in single-select mode and moves user selection too

### DIFF
--- a/src/selection.rs
+++ b/src/selection.rs
@@ -354,6 +354,15 @@ impl EventHandler for Selection {
     fn handle(&mut self, event: &Event) -> UpdateScreen {
         use crate::event::Event::*;
         match event {
+            Event::EvHeartBeat => {
+                debug!("HEARTBEAT!!!!!!!!!");
+                if self.to_run_auto_line_select {
+                    debug!("Running! to_run_auto_line_select!!!!!!!");
+                    self.act_move_line_cursor(1);
+                    self.to_run_auto_line_select = false;
+                }        
+            }
+
             EvActUp(diff) => {
                 self.act_move_line_cursor(*diff);
             }
@@ -556,13 +565,6 @@ impl Draw for Selection {
 
             let _ = self.draw_item(canvas, line_no, &item, line_cursor == self.line_cursor);
         }
-
-        if self.to_run_auto_line_select {
-            debug!("Running! to_run_auto_line_select");
-            // let s = self as *mut Selector;
-            // s.to_run_auto_line_select = false;
-        }
-
 
         Ok(())
     }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -56,6 +56,7 @@ pub struct Selection {
     // To avoid remember all items, we'll track the latest run_num and index.
     latest_select_run_num: u32,
     pre_selected_watermark: usize,
+    to_run_auto_line_select: bool,
     selector: Option<Rc<dyn Selector>>,
 }
 
@@ -77,6 +78,7 @@ impl Selection {
             theme: Arc::new(*DEFAULT_THEME),
             latest_select_run_num: 0,
             pre_selected_watermark: 0,
+            to_run_auto_line_select: false,
             selector: None,
         }
     }
@@ -136,6 +138,7 @@ impl Selection {
 
         if self.items.len() >= self.pre_selected_watermark {
             self.pre_select(&items);
+            self.to_run_auto_line_select = true;
         }
 
         self.items.append(items);
@@ -553,6 +556,13 @@ impl Draw for Selection {
 
             let _ = self.draw_item(canvas, line_no, &item, line_cursor == self.line_cursor);
         }
+
+        if self.to_run_auto_line_select {
+            debug!("Running! to_run_auto_line_select");
+            // let s = self as *mut Selector;
+            // s.to_run_auto_line_select = false;
+        }
+
 
         Ok(())
     }


### PR DESCRIPTION
This is related to my need [here](https://github.com/lotabout/skim/issues/403) - I want pre-selection to move the actual initial user selector and work also in single mode (without the `-m` flag).

At this point it works, even though the code is very hacky - Mainly, I am using the `EvHeartBeat` event to check whether the cursor can be moved or not yet.

I would love to hear your feedback:

1. As a feature - Is it something you'd like to merge into the project?
2. Do you have a better idea than putting the callback in EvHeartBeat?
3. What else should be done to merge this feature into skim?
