### PR TITLE
Match the latest :+SCROLL[-OFFSET] option

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -282,7 +282,7 @@ impl Model {
 
     // -> string
     fn parse_preview_offset(preview_window: &str) -> String {
-        for token in preview_window.split(':') {
+        for token in preview_window.split(':').rev() {
             if RE_PREVIEW_OFFSET.is_match(token) {
                 return token.to_string();
             }

--- a/test/test_skim.py
+++ b/test/test_skim.py
@@ -1079,11 +1079,17 @@ class TestSkim(TestBase):
         self.tmux.until(lambda lines: lines[-3].startswith('> foo bar'))
         self.tmux.send_keys(Key('Enter'))
 
-        args = '''-q "!foo\\ bar"'''
+        # prevent bang ("!" sign) expansion
+        self.tmux.send_keys(f"""set +o histexpand""", Key('Enter'))
+
+        args = '''-q "'!foo\\ bar"'''
         self.tmux.send_keys(f"""echo 'foo bar\nfoo  bar' | {self.sk(args)}""", Key('Enter'))
         self.tmux.until(lambda lines: lines.ready_with_matches(1))
         self.tmux.until(lambda lines: lines[-3].startswith('> foo  bar'))
         self.tmux.send_keys(Key('Enter'))
+
+        # revert option back
+        self.tmux.send_keys(f"""set -o histexpand""", Key('Enter'))
 
 
 def find_prompt(lines, interactive=False, reverse=False):


### PR DESCRIPTION
When multiple `--preview-window` arguments provided (e.g. one from
environment and another later from CLI) the last one have to have
presedence over others.