### PR TITLE
Add light colors parsing support

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -92,9 +92,7 @@ impl Perform for ANSIParser {
                 4 => attr.effect |= Effect::UNDERLINE,
                 5 => attr.effect |= Effect::BLINK,
                 7 => attr.effect |= Effect::REVERSE,
-                num if num >= 30 && num <= 37 => {
-                    attr.fg = Color::AnsiValue((num - 30) as u8);
-                }
+                num @ 30..=37 => attr.fg = Color::AnsiValue((num - 30) as u8),
                 38 => match iter.next() {
                     Some(&[2]) => {
                         // ESC[ 38;2;<r>;<g>;<b> m Select RGB foreground color
@@ -125,9 +123,7 @@ impl Perform for ANSIParser {
                     }
                 },
                 39 => attr.fg = Color::Default,
-                num if num >= 40 && num <= 47 => {
-                    attr.bg = Color::AnsiValue((num - 40) as u8);
-                }
+                num @ 40..=47 => attr.bg = Color::AnsiValue((num - 40) as u8),
                 48 => match iter.next() {
                     Some(&[2]) => {
                         // ESC[ 48;2;<r>;<g>;<b> m Select RGB background color
@@ -158,6 +154,8 @@ impl Perform for ANSIParser {
                     }
                 },
                 49 => attr.bg = Color::Default,
+                num @ 90..=97 => attr.fg = Color::AnsiValue((num - 82) as u8),
+                num @ 100..=107 => attr.bg = Color::AnsiValue((num - 92) as u8),
                 _ => {
                     trace!("ignore CSI {:?} m", params);
                 }


### PR DESCRIPTION
Support for the colors with code in [90, 97]  or [100, 107] when using `--ansi` option.

Take `num if num >= low && num <= high` to `num @ low..=high` in `match` expression.