### PR TITLE
fix: print version from Cargo.toml with latest clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "bitflags",
  "clap_lex",
  "indexmap",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ unicode-width = "0.1.9"
 log = "0.4.17"
 env_logger = { version = "0.9.0", optional = true }
 time = "0.3.13"
-clap = { version = "3.2.22", optional = true }
+clap = { version = "3.2.22", optional = true, features = ["cargo"] }
 tuikit = "0.5.0"
 vte = "0.11.0"
 fuzzy-matcher = "0.3.7"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -12,10 +12,8 @@ use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 
-use clap::{App, Arg, ArgMatches};
+use clap::{crate_version, App, Arg, ArgMatches};
 use skim::prelude::*;
-
-const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const USAGE: &str = "
 Usage: sk [options]
@@ -171,8 +169,8 @@ fn real_main() -> Result<i32, std::io::Error> {
     // parse options
     let opts = App::new("sk")
         .author("Jinzhou Zhang<lotabout@gmail.com>")
+        .version(crate_version!())
         .arg(Arg::with_name("help").long("help").short('h'))
-        .arg(Arg::with_name("version").long("version").short('v'))
         .arg(Arg::with_name("bind").long("bind").short('b').multiple(true).takes_value(true))
         .arg(Arg::with_name("multi").long("multi").short('m').multiple(true))
         .arg(Arg::with_name("no-multi").long("no-multi").multiple(true))
@@ -246,11 +244,6 @@ fn real_main() -> Result<i32, std::io::Error> {
 
     if opts.is_present("help") {
         write!(stdout, "{}", USAGE)?;
-        return Ok(0);
-    }
-
-    if opts.is_present("version") {
-        writeln!(stdout, "{}", VERSION)?;
         return Ok(0);
     }
 


### PR DESCRIPTION
Upgrading to clap 3 has changed some behavior in clap, as the version option is automatically populated. This means the custom code has never been executed.

Lets fix this by using the clap built in functionality to automatically use the crate version in the builtin version option.

This fixes commit 7d922a02a05b7787d17321175d67d32cd616afc1

Signed-off-by: Levente Polyak <levente@leventepolyak.net>