### PR TITLE
Refactor to clap-4 with derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,24 +96,37 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
- "indexmap",
+ "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -409,10 +422,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
+name = "heck"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -458,16 +471,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
 
 [[package]]
 name = "js-sys"
@@ -611,6 +614,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +742,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "skim"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "atty",
  "beef",
@@ -776,12 +803,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -873,6 +894,12 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vte"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "skim"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Zhang Jinzhou <lotabout@gmail.com>"]
 description = "Fuzzy Finder in rust!"
 documentation = "https://docs.rs/skim"
 homepage = "https://github.com/lotabout/skim"
 repository = "https://github.com/lotabout/skim"
-readme  = "README.md"
+readme = "README.md"
 keywords = ["fuzzy", "menu", "util"]
 license = "MIT"
 edition = "2018"
@@ -29,7 +29,7 @@ unicode-width = "0.1.9"
 log = "0.4.17"
 env_logger = { version = "0.9.0", optional = true }
 time = "0.3.13"
-clap = { version = "3.2.22", optional = true }
+clap = { version = "4.0.18", features = ["derive"], optional = true }
 tuikit = "0.5.0"
 vte = "0.11.0"
 fuzzy-matcher = "0.3.7"

--- a/examples/nth.rs
+++ b/examples/nth.rs
@@ -9,7 +9,7 @@ pub fn main() {
     let input = "foo 123";
 
     let options = SkimOptionsBuilder::default().query(Some("f")).build().unwrap();
-    let item_reader = SkimItemReader::new(SkimItemReaderOption::default().nth("2").build());
+    let item_reader = SkimItemReader::new(SkimItemReaderOption::default().nth(["2"]).build());
 
     let items = item_reader.of_bufread(Cursor::new(input));
     let selected_items = Skim::run_with(&options, Some(items))

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -469,7 +469,7 @@ mod tests {
         let input = "ab";
         let ansistring = ANSIParser::default().parse_ansi(input);
 
-        assert_eq!(false, ansistring.has_attrs());
+        assert!(!ansistring.has_attrs());
 
         let mut it = ansistring.iter();
         assert_eq!(Some(('a', Attr::default())), it.next());

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,274 +1,75 @@
-extern crate clap;
-extern crate env_logger;
-#[macro_use]
-extern crate log;
-extern crate atty;
-extern crate shlex;
-extern crate skim;
-extern crate time;
-
+use clap::Parser;
 use derive_builder::Builder;
-use std::env;
-use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Write};
-
-use clap::{App, Arg, ArgMatches};
+use log::debug;
 use skim::prelude::*;
+use std::{
+    env,
+    fs::File,
+    io::{self, BufRead, BufReader, BufWriter, Write},
+    path::Path,
+    process::exit,
+};
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+#[derive(Builder)]
+pub struct BinOptions<'a> {
+    filter: Option<&'a str>,
+    output_ending: char,
+    print_query: bool,
+    print_cmd: bool,
+}
 
-const USAGE: &str = "
-Usage: sk [options]
-
-  Options
-    -h, --help           print this help menu
-    --version            print out the current version of skim
-
-  Search
-    --tac                reverse the order of search result
-    --no-sort            Do not sort the result
-    -t, --tiebreak [score,begin,end,-score,length...]
-
-                         comma seperated criteria
-    -n, --nth 1,2..5     specify the fields to be matched
-    --with-nth 1,2..5    specify the fields to be transformed
-    -d, --delimiter \\t  specify the delimiter(in REGEX) for fields
-    -e, --exact          start skim in exact mode
-    --regex              use regex instead of fuzzy match
-    --algo=TYPE          Fuzzy matching algorithm:
-                         [skim_v1|skim_v2|clangd] (default: skim_v2)
-    --case [respect,ignore,smart] (default: smart)
-                         case sensitive or not
-
-  Interface
-    -b, --bind KEYBINDS  comma seperated keybindings, in KEY:ACTION
-                         such as 'ctrl-j:accept,ctrl-k:kill-line'
-    -m, --multi          Enable Multiple Selection
-    --no-multi           Disable Multiple Selection
-    --no-mouse           Disable mouse events
-    -c, --cmd ag         command to invoke dynamically
-    -i, --interactive    Start skim in interactive(command) mode
-    --color [BASE][,COLOR:ANSI]
-                         change color theme
-    --no-hscroll         Disable horizontal scroll
-    --keep-right         Keep the right end of the line visible on overflow
-    --skip-to-pattern    Line starts with the start of matched pattern
-    --no-clear-if-empty  Do not clear previous items if command returns empty result
-    --no-clear-start     Do not clear on start
-    --show-cmd-error     Send command error message if command fails
-
-  Layout
-    --layout=LAYOUT      Choose layout: [default|reverse|reverse-list]
-    --height=HEIGHT      Height of skim's window (--height 40%)
-    --no-height          Disable height feature
-    --min-height=HEIGHT  Minimum height when --height is given by percent
-                         (default: 10)
-    --margin=MARGIN      Screen Margin (TRBL / TB,RL / T,RL,B / T,R,B,L)
-                         e.g. (sk --margin 1,10%)
-    -p, --prompt '> '    prompt string for query mode
-    --cmd-prompt '> '    prompt string for command mode
-
-  Display
-    --ansi               parse ANSI color codes for input strings
-    --tabstop=SPACES     Number of spaces for a tab character (default: 8)
-    --inline-info        Display info next to query
-    --header=STR         Display STR next to info
-    --header-lines=N     The first N lines of the input are treated as header
-
-  History
-    --history=FILE       History file
-    --history-size=N     Maximum number of query history entries (default: 1000)
-    --cmd-history=FILE   command History file
-    --cmd-history-size=N Maximum number of command history entries (default: 1000)
-
-  Preview
-    --preview=COMMAND    command to preview current highlighted line ({})
-                         We can specify the fields. e.g. ({1}, {..3}, {0..})
-    --preview-window=OPT Preview window layout (default: right:50%)
-                         [up|down|left|right][:SIZE[%]][:hidden][:+SCROLL[-OFFSET]]
-
-  Scripting
-    -q, --query \"\"       specify the initial query
-    --cmd-query \"\"       specify the initial query for interactive mode
-    --expect KEYS        comma seperated keys that can be used to complete skim
-    --read0              Read input delimited by ASCII NUL(\\0) characters
-    --print0             Print output delimited by ASCII NUL(\\0) characters
-    --no-clear-start     Do not clear screen on start
-    --no-clear           Do not clear screen on exit
-    --print-query        Print query as the first line
-    --print-cmd          Print command query as the first line (after --print-query)
-    --print-score        Print matching score in filter output (with --filter)
-    -1, --select-1       Automatically select the only match
-    -0, --exit-0         Exit immediately when there's no match
-    --sync               Synchronous search for multi-staged filtering
-    --pre-select-n=NUM   Pre-select the first n items in multi-selection mode
-    --pre-select-pat=REGEX
-                         Pre-select the matched items in multi-selection mode
-    --pre-select-items=$'item1\\nitem2'
-                         Pre-select the items separated by newline character
-    --pre-select-file=FILENAME
-                         Pre-select the items read from file
-
-  Environment variables
-    SKIM_DEFAULT_COMMAND Default command to use when input is tty
-    SKIM_DEFAULT_OPTIONS Default options (e.g. '--ansi --regex')
-                         You should not include other environment variables
-                         (e.g. '-c \"$HOME/bin/ag\"')
-
-  Removed
-    -I replstr           replace `replstr` with the selected item
-
-  Reserved (not used for now)
-    --extended
-    --literal
-    --cycle
-    --hscroll-off=COL
-    --filepath-word
-    --jump-labels=CHARS
-    --border
-    --no-bold
-    --info
-    --pointer
-    --marker
-    --phony
-";
-
-const DEFAULT_HISTORY_SIZE: usize = 1000;
-
-//------------------------------------------------------------------------------
 fn main() {
-    env_logger::builder().format_timestamp_nanos().init();
+    env_logger::builder().format_timestamp_nanos();
 
     match real_main() {
-        Ok(exit_code) => std::process::exit(exit_code),
+        Ok(exit_code) => exit(exit_code),
         Err(err) => {
             // if downstream pipe is closed, exit silently, see PR#279
-            if err.kind() == std::io::ErrorKind::BrokenPipe {
-                std::process::exit(0)
+            if err.kind() == io::ErrorKind::BrokenPipe {
+                exit(0)
             }
-            std::process::exit(2)
+            exit(2)
         }
     }
 }
 
-#[rustfmt::skip]
-fn real_main() -> Result<i32, std::io::Error> {
-    let mut stdout = std::io::stdout();
+fn real_main() -> Result<i32, io::Error> {
+    let mut stdout = io::stdout();
 
     let mut args = Vec::new();
+    let mut cli_args = env::args();
 
-    args.push(env::args().next().expect("there should be at least one arg: the application name"));
-    args.extend(env::var("SKIM_DEFAULT_OPTIONS")
-        .ok()
-        .and_then(|val| shlex::split(&val))
-        .unwrap_or_default());
-    for arg in env::args().skip(1) {
+    args.push(
+        cli_args
+            .next()
+            .expect("there should be at least one arg: the application name"),
+    );
+    args.extend(
+        env::var("SKIM_DEFAULT_OPTIONS")
+            .ok()
+            .and_then(|val| shlex::split(&val))
+            .unwrap_or_default(),
+    );
+    for arg in cli_args {
         args.push(arg);
     }
 
-
     //------------------------------------------------------------------------------
     // parse options
-    let opts = App::new("sk")
-        .author("Jinzhou Zhang<lotabout@gmail.com>")
-        .arg(Arg::with_name("help").long("help").short('h'))
-        .arg(Arg::with_name("version").long("version").short('v'))
-        .arg(Arg::with_name("bind").long("bind").short('b').multiple(true).takes_value(true))
-        .arg(Arg::with_name("multi").long("multi").short('m').multiple(true))
-        .arg(Arg::with_name("no-multi").long("no-multi").multiple(true))
-        .arg(Arg::with_name("prompt").long("prompt").short('p').multiple(true).takes_value(true).default_value("> "))
-        .arg(Arg::with_name("cmd-prompt").long("cmd-prompt").multiple(true).takes_value(true).default_value("c> "))
-        .arg(Arg::with_name("expect").long("expect").multiple(true).takes_value(true))
-        .arg(Arg::with_name("tac").long("tac").multiple(true))
-        .arg(Arg::with_name("tiebreak").long("tiebreak").short('t').multiple(true).takes_value(true))
-        .arg(Arg::with_name("ansi").long("ansi").multiple(true))
-        .arg(Arg::with_name("exact").long("exact").short('e').multiple(true))
-        .arg(Arg::with_name("cmd").long("cmd").short('c').multiple(true).takes_value(true))
-        .arg(Arg::with_name("interactive").long("interactive").short('i').multiple(true))
-        .arg(Arg::with_name("query").long("query").short('q').multiple(true).takes_value(true))
-        .arg(Arg::with_name("cmd-query").long("cmd-query").multiple(true).takes_value(true))
-        .arg(Arg::with_name("regex").long("regex").multiple(true))
-        .arg(Arg::with_name("delimiter").long("delimiter").short('d').multiple(true).takes_value(true))
-        .arg(Arg::with_name("nth").long("nth").short('n').multiple(true).takes_value(true))
-        .arg(Arg::with_name("with-nth").long("with-nth").multiple(true).takes_value(true))
-        .arg(Arg::with_name("replstr").short('I').multiple(true).takes_value(true))
-        .arg(Arg::with_name("color").long("color").multiple(true).takes_value(true))
-        .arg(Arg::with_name("margin").long("margin").multiple(true).takes_value(true).default_value("0,0,0,0"))
-        .arg(Arg::with_name("min-height").long("min-height").multiple(true).takes_value(true).default_value("10"))
-        .arg(Arg::with_name("height").long("height").multiple(true).takes_value(true).default_value("100%"))
-        .arg(Arg::with_name("no-height").long("no-height").multiple(true))
-        .arg(Arg::with_name("no-clear").long("no-clear").multiple(true))
-        .arg(Arg::with_name("no-clear-start").long("no-clear-start").multiple(true))
-        .arg(Arg::with_name("no-mouse").long("no-mouse").multiple(true))
-        .arg(Arg::with_name("preview").long("preview").multiple(true).takes_value(true))
-        .arg(Arg::with_name("preview-window").long("preview-window").multiple(true).takes_value(true).default_value("right:50%"))
-        .arg(Arg::with_name("reverse").long("reverse").multiple(true))
-
-        .arg(Arg::with_name("algorithm").long("algo").multiple(true).takes_value(true).default_value("skim_v2"))
-        .arg(Arg::with_name("case").long("case").multiple(true).takes_value(true).default_value("smart"))
-        .arg(Arg::with_name("literal").long("literal").multiple(true))
-        .arg(Arg::with_name("cycle").long("cycle").multiple(true))
-        .arg(Arg::with_name("no-hscroll").long("no-hscroll").multiple(true))
-        .arg(Arg::with_name("hscroll-off").long("hscroll-off").multiple(true).takes_value(true).default_value("10"))
-        .arg(Arg::with_name("filepath-word").long("filepath-word").multiple(true))
-        .arg(Arg::with_name("jump-labels").long("jump-labels").multiple(true).takes_value(true).default_value("abcdefghijklmnopqrstuvwxyz"))
-        .arg(Arg::with_name("border").long("border").multiple(true))
-        .arg(Arg::with_name("inline-info").long("inline-info").multiple(true))
-        .arg(Arg::with_name("header").long("header").multiple(true).takes_value(true).default_value(""))
-        .arg(Arg::with_name("header-lines").long("header-lines").multiple(true).takes_value(true).default_value("0"))
-        .arg(Arg::with_name("tabstop").long("tabstop").multiple(true).takes_value(true).default_value("8"))
-        .arg(Arg::with_name("no-bold").long("no-bold").multiple(true))
-        .arg(Arg::with_name("history").long("history").multiple(true).takes_value(true))
-        .arg(Arg::with_name("cmd-history").long("cmd-history").multiple(true).takes_value(true))
-        .arg(Arg::with_name("history-size").long("history-size").multiple(true).takes_value(true).default_value("1000"))
-        .arg(Arg::with_name("cmd-history-size").long("cmd-history-size").multiple(true).takes_value(true).default_value("1000"))
-        .arg(Arg::with_name("print-query").long("print-query").multiple(true))
-        .arg(Arg::with_name("print-cmd").long("print-cmd").multiple(true))
-        .arg(Arg::with_name("print-score").long("print-score").multiple(true))
-        .arg(Arg::with_name("read0").long("read0").multiple(true))
-        .arg(Arg::with_name("print0").long("print0").multiple(true))
-        .arg(Arg::with_name("sync").long("sync").multiple(true))
-        .arg(Arg::with_name("extended").long("extended").short('x').multiple(true))
-        .arg(Arg::with_name("no-sort").long("no-sort").multiple(true))
-        .arg(Arg::with_name("select-1").long("select-1").short('1').multiple(true))
-        .arg(Arg::with_name("exit-0").long("exit-0").short('0').multiple(true))
-        .arg(Arg::with_name("filter").long("filter").short('f').takes_value(true).multiple(true))
-        .arg(Arg::with_name("layout").long("layout").multiple(true).takes_value(true).default_value("default"))
-        .arg(Arg::with_name("keep-right").long("keep-right").multiple(true))
-        .arg(Arg::with_name("skip-to-pattern").long("skip-to-pattern").multiple(true).takes_value(true).default_value(""))
-        .arg(Arg::with_name("pre-select-n").long("pre-select-n").multiple(true).takes_value(true).default_value("0"))
-        .arg(Arg::with_name("pre-select-pat").long("pre-select-pat").multiple(true).takes_value(true).default_value(""))
-        .arg(Arg::with_name("pre-select-items").long("pre-select-items").multiple(true).takes_value(true))
-        .arg(Arg::with_name("pre-select-file").long("pre-select-file").multiple(true).takes_value(true).default_value(""))
-        .arg(Arg::with_name("no-clear-if-empty").long("no-clear-if-empty").multiple(true))
-        .arg(Arg::with_name("show-cmd-error").long("show-cmd-error").multiple(true))
-        .get_matches_from(args);
-
-    if opts.is_present("help") {
-        write!(stdout, "{}", USAGE)?;
-        return Ok(0);
-    }
-
-    if opts.is_present("version") {
-        writeln!(stdout, "{}", VERSION)?;
-        return Ok(0);
-    }
+    let cli = Cli::parse_from(args);
 
     //------------------------------------------------------------------------------
-    let mut options = parse_options(&opts);
-
-    let preview_window_joined = opts.values_of("preview-window").map(|x| x.collect::<Vec<_>>().join(":"));
-    options.preview_window = preview_window_joined.as_deref();
+    let mut options = parse_options(&cli);
 
     //------------------------------------------------------------------------------
     // initialize collector
     let item_reader_option = SkimItemReaderOption::default()
-        .ansi(opts.is_present("ansi"))
-        .delimiter(opts.values_of("delimiter").and_then(|vals| vals.last()).unwrap_or(""))
-        .with_nth(opts.values_of("with-nth").and_then(|vals| vals.last()).unwrap_or(""))
-        .nth(opts.values_of("nth").and_then(|vals| vals.last()).unwrap_or(""))
-        .read0(opts.is_present("read0"))
-        .show_error(opts.is_present("show-cmd-error"))
+        .ansi(cli.ansi)
+        .delimiter(&cli.delimiter)
+        .with_nth(&cli.with_nth)
+        .nth(&cli.nth)
+        .read0(cli.read0)
+        .show_error(cli.show_cmd_error)
         .build();
 
     let cmd_collector = Rc::new(RefCell::new(SkimItemReader::new(item_reader_option)));
@@ -276,69 +77,60 @@ fn real_main() -> Result<i32, std::io::Error> {
 
     //------------------------------------------------------------------------------
     // read in the history file
-    let fz_query_histories = opts.values_of("history").and_then(|vals| vals.last());
-    let cmd_query_histories = opts.values_of("cmd-history").and_then(|vals| vals.last());
-    let query_history = fz_query_histories.and_then(|filename| read_file_lines(filename).ok()).unwrap_or_default();
-    let cmd_history = cmd_query_histories.and_then(|filename| read_file_lines(filename).ok()).unwrap_or_default();
 
-    if fz_query_histories.is_some() || cmd_query_histories.is_some() {
+    let query_history = try_read_file_lines(cli.history.as_deref());
+    let cmd_history = try_read_file_lines(cli.cmd_history.as_deref());
+
+    if cli.history.is_some() || cli.cmd_history.is_some() {
         options.query_history = &query_history;
         options.cmd_history = &cmd_history;
+
         // bind ctrl-n and ctrl-p to handle history
         options.bind.insert(0, "ctrl-p:previous-history,ctrl-n:next-history");
     }
 
     //------------------------------------------------------------------------------
     // handle pre-selection options
-    let pre_select_n: Option<usize> = opts.values_of("pre-select-n").and_then(|vals| vals.last()).and_then(|s| s.parse().ok());
-    let pre_select_pat = opts.values_of("pre-select-pat").and_then(|vals| vals.last());
-    let pre_select_items: Option<Vec<String>> = opts.values_of("pre-select-items").map(|vals| vals.flat_map(|m|m.split('\n')).map(|s|s.to_string()).collect());
-    let pre_select_file = opts.values_of("pre-select-file").and_then(|vals| vals.last());
+    let selector = DefaultSkimSelector::default()
+        .first_n(cli.pre_select_n)
+        .regex(&cli.pre_select_pat)
+        .preset(
+            cli.pre_select_items
+                .as_ref()
+                .map(|s| s.split('\n').map(str::to_owned).collect::<Vec<String>>())
+                .unwrap_or_default(),
+        )
+        .preset(try_read_file_lines(cli.pre_select_file.as_deref()));
+    options.selector = Some(Rc::new(selector));
 
-    if pre_select_n.is_some() || pre_select_pat.is_some() || pre_select_items.is_some() || pre_select_file.is_some() {
-        let first_n = pre_select_n.unwrap_or(0);
-        let pattern = pre_select_pat.unwrap_or("");
-        let preset_items = pre_select_items.unwrap_or_default();
-        let preset_file = pre_select_file.and_then(|filename| read_file_lines(filename).ok()).unwrap_or_default();
-
-        let selector = DefaultSkimSelector::default()
-            .first_n(first_n)
-            .regex(pattern)
-            .preset(preset_items)
-            .preset(preset_file);
-        options.selector = Some(Rc::new(selector));
-    }
-
+    //------------------------------------------------------------------------------
+    // mut  ==>  const
     let options = options;
 
     //------------------------------------------------------------------------------
     let bin_options = BinOptionsBuilder::default()
-        .filter(opts.values_of("filter").and_then(|vals| vals.last()))
-        .print_query(opts.is_present("print-query"))
-        .print_cmd(opts.is_present("print-cmd"))
-        .output_ending(if opts.is_present("print0") { "\0" } else { "\n" })
+        .filter(cli.filter.as_deref())
+        .print_query(cli.print_query)
+        .print_cmd(cli.print_cmd)
+        .output_ending(if cli.print0 { '\0' } else { '\n' })
         .build()
         .expect("");
 
     //------------------------------------------------------------------------------
     // read from pipe or command
-    let rx_item = if atty::isnt(atty::Stream::Stdin) {
-            let rx_item = cmd_collector.borrow().of_bufread(BufReader::new(std::io::stdin()));
-            Some(rx_item)
-        } else {
-         None
-    };
+    let rx_item =
+        atty::isnt(atty::Stream::Stdin).then(|| cmd_collector.borrow().of_bufread(BufReader::new(io::stdin())));
 
     //------------------------------------------------------------------------------
     // filter mode
-    if opts.is_present("filter") {
+    if cli.filter.is_some() {
         return filter(&bin_options, &options, rx_item);
     }
 
     //------------------------------------------------------------------------------
     let output = Skim::run_with(&options, rx_item);
-    if output.is_none() { // error
-        return Ok(135);
+    if output.is_none() {
+        return Ok(135); // error
     }
 
     //------------------------------------------------------------------------------
@@ -357,7 +149,7 @@ fn real_main() -> Result<i32, std::io::Error> {
         write!(stdout, "{}{}", output.cmd, bin_options.output_ending)?;
     }
 
-    if opts.is_present("expect") {
+    if !cli.expect.is_empty() {
         match output.final_event {
             Event::EvActAccept(Some(accept_key)) => {
                 write!(stdout, "{}{}", accept_key, bin_options.output_ending)?;
@@ -375,147 +167,113 @@ fn real_main() -> Result<i32, std::io::Error> {
 
     //------------------------------------------------------------------------------
     // write the history with latest item
-    if let Some(file) = fz_query_histories {
-        let limit = opts.values_of("history-size").and_then(|vals| vals.last())
-            .and_then(|size| size.parse::<usize>().ok())
-            .unwrap_or(DEFAULT_HISTORY_SIZE);
-        write_history_to_file(&query_history, &output.query, limit, file)?;
+    if let Some(file) = &cli.history {
+        write_history_to_file(&query_history, &output.query, cli.history_size, file)?;
     }
 
-    if let Some(file) = cmd_query_histories {
-        let limit = opts.values_of("cmd-history-size").and_then(|vals| vals.last())
-            .and_then(|size| size.parse::<usize>().ok())
-            .unwrap_or(DEFAULT_HISTORY_SIZE);
-        write_history_to_file(&cmd_history, &output.cmd, limit, file)?;
+    if let Some(file) = &cli.cmd_history {
+        write_history_to_file(&cmd_history, &output.cmd, cli.cmd_history_size, file)?;
     }
 
-    Ok(if output.selected_items.is_empty() { 1 } else { 0 })
+    // nothing -> 1
+    // something -> 0
+    Ok(output.selected_items.is_empty().into())
 }
 
-fn parse_options(options: &ArgMatches) -> SkimOptions<'_> {
-    SkimOptionsBuilder::default()
-        .color(options.values_of("color").and_then(|vals| vals.last()))
-        .min_height(options.values_of("min-height").and_then(|vals| vals.last()))
-        .no_height(options.is_present("no-height"))
-        .height(options.values_of("height").and_then(|vals| vals.last()))
-        .margin(options.values_of("margin").and_then(|vals| vals.last()))
-        .preview(options.values_of("preview").and_then(|vals| vals.last()))
-        .cmd(options.values_of("cmd").and_then(|vals| vals.last()))
-        .query(options.values_of("query").and_then(|vals| vals.last()))
-        .cmd_query(options.values_of("cmd-query").and_then(|vals| vals.last()))
-        .interactive(options.is_present("interactive"))
-        .prompt(options.values_of("prompt").and_then(|vals| vals.last()))
-        .cmd_prompt(options.values_of("cmd-prompt").and_then(|vals| vals.last()))
-        .bind(
-            options
-                .values_of("bind")
-                .map(|x| x.collect::<Vec<_>>())
-                .unwrap_or_default(),
-        )
-        .expect(options.values_of("expect").map(|x| x.collect::<Vec<_>>().join(",")))
-        .multi(if options.is_present("no-multi") {
-            false
-        } else {
-            options.is_present("multi")
+// Because we are always using default value logic to deal with read lines,
+// it would be better to return empty Vec when failing
+fn try_read_file_lines(path: Option<&Path>) -> Vec<String> {
+    path.and_then(|p| File::open(p).ok())
+        .and_then(|f| {
+            let lines: Result<Vec<String>, _> = BufReader::new(f).lines().collect();
+            debug!("file content: {:?}", lines);
+            lines.ok()
         })
-        .layout(options.values_of("layout").and_then(|vals| vals.last()).unwrap_or(""))
-        .reverse(options.is_present("reverse"))
-        .no_hscroll(options.is_present("no-hscroll"))
-        .no_mouse(options.is_present("no-mouse"))
-        .no_clear(options.is_present("no-clear"))
-        .no_clear_start(options.is_present("no-clear-start"))
-        .tabstop(options.values_of("tabstop").and_then(|vals| vals.last()))
-        .tiebreak(options.values_of("tiebreak").map(|x| x.collect::<Vec<_>>().join(",")))
-        .tac(options.is_present("tac"))
-        .nosort(options.is_present("no-sort"))
-        .exact(options.is_present("exact"))
-        .regex(options.is_present("regex"))
-        .delimiter(options.values_of("delimiter").and_then(|vals| vals.last()))
-        .inline_info(options.is_present("inline-info"))
-        .header(options.values_of("header").and_then(|vals| vals.last()))
-        .header_lines(
-            options
-                .values_of("header-lines")
-                .and_then(|vals| vals.last())
-                .map(|s| s.parse::<usize>().unwrap_or(0))
-                .unwrap_or(0),
-        )
-        .layout(options.values_of("layout").and_then(|vals| vals.last()).unwrap_or(""))
-        .algorithm(FuzzyAlgorithm::of(
-            options.values_of("algorithm").and_then(|vals| vals.last()).unwrap(),
-        ))
-        .case(match options.value_of("case") {
-            Some("smart") => CaseMatching::Smart,
-            Some("ignore") => CaseMatching::Ignore,
-            _ => CaseMatching::Respect,
-        })
-        .keep_right(options.is_present("keep-right"))
-        .skip_to_pattern(
-            options
-                .values_of("skip-to-pattern")
-                .and_then(|vals| vals.last())
-                .unwrap_or(""),
-        )
-        .select1(options.is_present("select-1"))
-        .exit0(options.is_present("exit-0"))
-        .sync(options.is_present("sync"))
-        .no_clear_if_empty(options.is_present("no-clear-if-empty"))
-        .build()
-        .unwrap()
+        .unwrap_or_else(|| vec![])
 }
 
-fn read_file_lines(filename: &str) -> Result<Vec<String>, std::io::Error> {
-    let file = File::open(filename)?;
-    let ret = BufReader::new(file).lines().collect();
-    debug!("file content: {:?}", ret);
-    ret
+fn to_strs(strings: &[String]) -> Vec<&str> {
+    strings.into_iter().map(String::as_str).collect()
 }
 
-fn write_history_to_file(
-    orig_history: &[String],
-    latest: &str,
-    limit: usize,
-    filename: &str,
-) -> Result<(), std::io::Error> {
-    if orig_history.last().map(|l| l.as_str()) == Some(latest) {
+fn write_history_to_file(orig_history: &[String], latest: &str, limit: usize, path: &Path) -> Result<(), io::Error> {
+    if let Some(true) = orig_history.last().map(|s| s == latest) {
         // no point of having at the end of the history 5x the same command...
         return Ok(());
-    }
-    let additional_lines = if latest.trim().is_empty() { 0 } else { 1 };
-    let start_index = if orig_history.len() + additional_lines > limit {
-        orig_history.len() + additional_lines - limit
-    } else {
-        0
     };
 
-    let mut history = orig_history[start_index..].to_vec();
-    history.push(latest.to_string());
+    let additional_lines = usize::from(!latest.trim().is_empty());
+    let start_index = (orig_history.len() + additional_lines).saturating_sub(limit);
 
-    let file = File::create(filename)?;
+    let mut history = orig_history[start_index..].to_vec();
+    history.push(latest.to_owned());
+
+    let file = File::create(path)?;
     let mut file = BufWriter::new(file);
     file.write_all(history.join("\n").as_bytes())?;
+
     Ok(())
 }
 
-#[derive(Builder)]
-pub struct BinOptions<'a> {
-    filter: Option<&'a str>,
-    output_ending: &'a str,
-    print_query: bool,
-    print_cmd: bool,
+fn parse_options<'a>(options: &'a Cli) -> SkimOptions<'a> {
+    SkimOptionsBuilder::default()
+        .color(to_strs(&options.color))
+        .min_height(Some(&options.min_height))
+        .no_height(options.no_height)
+        .height(Some(&options.height))
+        .margin(to_strs(&options.margin))
+        .preview(options.preview.as_deref())
+        .preview_window(Some(&options.preview_window))
+        .cmd(options.cmd.as_deref())
+        .query(options.query.as_deref())
+        .cmd_query(options.cmd_query.as_deref())
+        .interactive(options.interactive)
+        .prompt(Some(&options.prompt))
+        .cmd_prompt(Some(&options.cmd_prompt))
+        .bind(to_strs(&options.bind))
+        .expect(to_strs(&options.expect))
+        .multi(!options.no_multi && options.multi)
+        .layout(options.layout.clone())
+        .reverse(options.reverse)
+        .no_hscroll(options.no_hscroll)
+        .no_mouse(options.no_mouse)
+        .no_clear(options.no_clear)
+        .tabstop(Some(options.tabstop))
+        .tiebreak(options.tiebreak.clone())
+        .tac(options.tac)
+        .nosort(options.no_sort)
+        .exact(options.exact)
+        .regex(options.regex)
+        .delimiter(&options.delimiter)
+        .inline_info(options.inline_info)
+        .header(options.header.as_deref())
+        .header_lines(options.header_lines)
+        .algorithm(options.algorithm)
+        .case(options.case)
+        .keep_right(options.keep_right)
+        .skip_to_pattern(&options.skip_to_pattern)
+        .select1(options.select_1)
+        .exit0(options.exit_0)
+        .sync(options.sync)
+        .no_clear_if_empty(options.no_clear_if_empty)
+        .no_clear_start(options.no_clear_start)
+        .build()
+        .unwrap()
 }
 
 pub fn filter(
     bin_option: &BinOptions,
     options: &SkimOptions,
     source: Option<SkimItemReceiver>,
-) -> Result<i32, std::io::Error> {
-    let mut stdout = std::io::stdout();
+) -> Result<i32, io::Error> {
+    let mut stdout = io::stdout();
 
-    let default_command = match env::var("SKIM_DEFAULT_COMMAND").as_ref().map(String::as_ref) {
-        Ok("") | Err(_) => "find .".to_owned(),
-        Ok(val) => val.to_owned(),
-    };
+    let default_command = match env::var("SKIM_DEFAULT_COMMAND").as_deref() {
+        Ok("") | Err(_) => "find .",
+        Ok(val) => val,
+    }
+    .to_owned();
+
     let query = bin_option.filter.unwrap_or("");
     let cmd = options.cmd.unwrap_or(&default_command);
 
@@ -561,5 +319,7 @@ pub fn filter(
             write!(stdout, "{}{}", item.output(), bin_option.output_ending)
         })?;
 
-    Ok(if num_matched == 0 { 1 } else { 0 })
+    // 0 -> 1
+    // not 0 -> 0
+    Ok((num_matched == 0).into())
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -189,11 +189,11 @@ fn try_read_file_lines(path: Option<&Path>) -> Vec<String> {
             debug!("file content: {:?}", lines);
             lines.ok()
         })
-        .unwrap_or_else(|| vec![])
+        .unwrap_or_default()
 }
 
 fn to_strs(strings: &[String]) -> Vec<&str> {
-    strings.into_iter().map(String::as_str).collect()
+    strings.iter().map(String::as_str).collect()
 }
 
 fn write_history_to_file(orig_history: &[String], latest: &str, limit: usize, path: &Path) -> Result<(), io::Error> {
@@ -215,7 +215,7 @@ fn write_history_to_file(orig_history: &[String], latest: &str, limit: usize, pa
     Ok(())
 }
 
-fn parse_options<'a>(options: &'a Cli) -> SkimOptions<'a> {
+fn parse_options(options: &Cli) -> SkimOptions {
     SkimOptionsBuilder::default()
         .color(to_strs(&options.color))
         .min_height(Some(&options.min_height))
@@ -233,7 +233,7 @@ fn parse_options<'a>(options: &'a Cli) -> SkimOptions<'a> {
         .bind(to_strs(&options.bind))
         .expect(to_strs(&options.expect))
         .multi(!options.no_multi && options.multi)
-        .layout(options.layout.clone())
+        .layout(options.layout)
         .reverse(options.reverse)
         .no_hscroll(options.no_hscroll)
         .no_mouse(options.no_mouse)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use crate::{CaseMatching, Layout};
 use clap::Parser;
 use std::path::PathBuf;
 
-const USAGE: &'static str = r#"
+const USAGE: &str = r#"
 Fuzzy Finder in rust!
 
 Zhang Jinzhou <lotabout@gmail.com>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,400 @@
+use crate::engine::fuzzy::FuzzyAlgorithm;
+use crate::item::RankCriteria;
+use crate::{CaseMatching, Layout};
+use clap::Parser;
+use std::path::PathBuf;
+
+const USAGE: &'static str = r#"
+Fuzzy Finder in rust!
+
+Zhang Jinzhou <lotabout@gmail.com>
+
+Usage: sk [OPTIONS]
+
+Options
+  -h, --help                        Print help information
+  -V, --version                     Print version information
+
+Search
+      --tac                         Reverse the order of search result
+      --no-sort                     Do not sort the result
+  -t, --tiebreak=[score, -score, begin, -begin, end, -end, length, -length]
+                                    Comma seperated criteria
+  -n, --nth=1,2..5                  Specify the fields to be matched
+      --with-nth=1,2..5             Specify the fields to be transformed
+  -d, --delimiter='[\t\n ]+'        Specify the delimiter (in REGEX) for fields
+  -e, --exact                       Start skim in exact mode
+      --regex                       Use regex instead of fuzzy match
+      --algo=[skim_v1|skim_v2|clangd] (default: skim_v2)
+                                    Fuzzy matching pub algorithm
+      --case=[respect|ignore|smart] (default: smart)
+                                    Case sensitive or not
+
+Interface
+  -b, --bind=<KEYBINDS>             Comma seperated keybindings, in pub KEY:ACTION,
+                                    such as 'ctrl-pub j:accept,ctrl-k:kill-line'
+  -m, --multi                       Enable Multiple Selection
+      --no-multi                    Disable Multiple Selection
+      --no-mouse                    Disable mouse events
+  -c, --cmd=rg                      Command to invoke dynamically
+  -i, --interactive                 Start skim in interactive (command) mode
+      --color=[BASE][,COLOR:ANSI]
+                                    Change color theme
+      --no-hscroll                  Disable horizontal scroll
+      --keep-right                  Keep the right end of the line visible on overflow
+      --skip-to-pattern=""          Line starts with the start of matched pattern
+      --no-clear-if-empty           Do not clear previous items if command returns empty result
+      --no-clear-start              Do not clear on start
+      --show-cmd-error              Send command error message if command fails
+
+Layout
+      --layout=[default|reverse|reverse-list]
+                                    Choose layout
+      --reverse                     Shortcut for `layout='reverse'`
+      --height=100%                 Height of skim's window
+      --no-height                   Disable height feature
+      --min-height=10               Minimum height when --height is given by percent
+      --margin=0,0,0,0              Screen Margin (TRBL / TB,RL / T,RL,B / T,R,B,L)
+                                    e.g. `sk --margin 1,10%`
+  -p, --prompt='> '                 Prompt string for query mode
+      --cmd-prompt='c> '            Prompt string for command mode
+
+Display
+      --ansi                        Parse ANSI color codes for input strings
+      --tabstop=8                   Number of spaces for a tab character
+      --header=<STR>                Display STR next to info
+      --header-lines=0              The first N lines of the input are treated as header
+      --inline-info                 Display info next to query
+
+History
+      --history=<FILE>              History file
+      --history-size=1000           Maximum number of query history entries
+      --cmd-history=<FILE>          Command History file
+      --cmd-history-size=1000       Maximum number of command history entries
+
+Preview
+      --preview=<COMMAND>           Command to preview current highlighted line ({})
+                                    We can specify the fields. e.g. ({1}, {..3}, {0..})
+      --preview-window=right:50%    Preview window layout
+                                    [up|down|left|right][:SIZE[%]][:hidden][:+SCROLL[-OFFSET]]
+
+Scripting
+  -q, --query=""                    Specify the initial query
+      --cmd-query=""                Specify the initial query for interactive mode
+      --expect=<KEYS>               Comma seperated keys that can be used to complete skim
+      --read0                       Read input delimited by ASCII NUL(\0) characters
+      --print0                      Print output delimited by ASCII NUL(\0) characters
+      --no-clear-start              Do not clear on start
+      --no-clear                    Do not clear screen on exit
+  -f, --filter <FILTER>             Filter mode, output the score and the item to stdout
+      --print-query                 Print query as the first line
+      --print-cmd                   Print command query as the first line (after --print-query)
+      --print-score                 Print matching score in filter output (with --filter)
+  -1, --select-1                    Automatically select the only match
+  -0, --exit-0                      Exit immediately when there's no match
+      --sync                        Synchronous search for multi-staged filtering
+      --pre-select-n=0              Pre-select the first n items in multi-selection mode
+      --pre-select-pat=""           Pre-select the matched items in multi-selection mode
+      --pre-select-items=$'item1\nitem2'
+                                    Pre-select the matched items in multi-selection mode
+      --pre-select-file=<FILE>      Pre-select the items read from file
+
+Removed
+  -I <REPLSTR>                      Replace `replstr` with the selected item
+
+Reserved (not used for now)
+  -x, --extended
+      --literal
+      --cycle
+      --hscroll-off=10
+      --filepath-word
+      --jump-labels='abcdefghijklmnopqrstuvwxyz'
+      --border
+      --no-bold
+
+Environment variables
+        SKIM_DEFAULT_COMMAND        Default command to use when input is tty
+        SKIM_DEFAULT_OPTIONS        Default options (e.g. '--ansi --regex')
+"#;
+
+#[derive(Parser)]
+#[command(name = "sk", version, override_help = USAGE)]
+pub struct Cli {
+    /* Search */
+    /// Reverse the order of search result
+    #[arg(long)]
+    pub tac: bool,
+
+    /// Do not sort the result
+    #[arg(long)]
+    pub no_sort: bool,
+
+    /// Comma seperated criteria
+    #[arg(short, long)]
+    pub tiebreak: Vec<RankCriteria>,
+
+    /// Specify the fields to be matched
+    #[arg(short, long)]
+    pub nth: Vec<String>,
+
+    /// Specify the fields to be transformed
+    #[arg(long)]
+    pub with_nth: Vec<String>,
+
+    /// Specify the delimiter (in REGEX) for fields
+    #[arg(short, long, default_value = "")]
+    pub delimiter: String,
+
+    /// Start skim in exact mode
+    #[arg(short, long)]
+    pub exact: bool,
+
+    /// Use regex instead of fuzzy match
+    #[arg(long)]
+    pub regex: bool,
+
+    /// Fuzzy matching pub algorithm
+    #[arg(value_enum, long = "algo", default_value_t = FuzzyAlgorithm::SkimV2)]
+    pub algorithm: FuzzyAlgorithm,
+
+    /// Case sensitive or not
+    #[arg(value_enum, long, default_value_t = CaseMatching::Smart)]
+    pub case: CaseMatching,
+
+    /* Interface */
+    /// Comma seperated keybindings, in pub KEY:ACTION,
+    /// such as 'ctrl-pub j:accept,ctrl-k:kill-line'
+    #[arg(short, long)]
+    pub bind: Vec<String>,
+
+    /// Enable Multiple Selection
+    #[arg(short, long)]
+    pub multi: bool,
+
+    /// Disable Multiple Selection
+    #[arg(long)]
+    pub no_multi: bool,
+
+    /// Disable mouse events
+    #[arg(long)]
+    pub no_mouse: bool,
+
+    /// Command to invoke dynamically
+    #[arg(short, long)]
+    pub cmd: Option<String>,
+
+    /// Start skim in interactive (command) mode
+    #[arg(short, long)]
+    pub interactive: bool,
+
+    /// Change color theme
+    #[arg(long)]
+    pub color: Vec<String>,
+
+    /// Disable horizontal scroll
+    #[arg(long)]
+    pub no_hscroll: bool,
+
+    /// Keep the right end of the line visible on overflow
+    #[arg(long)]
+    pub keep_right: bool,
+
+    /// Line starts with the start of matched pattern
+    #[arg(long, default_value = "")]
+    pub skip_to_pattern: String,
+
+    /// Do not clear previous items if command returns empty result
+    #[arg(long)]
+    pub no_clear_if_empty: bool,
+
+    /// Do not clear on start
+    #[arg(long)]
+    pub no_clear_start: bool,
+
+    /// Send command error message if command fails
+    #[arg(long)]
+    pub show_cmd_error: bool,
+
+    /* Layout */
+    /// Choose layout
+    #[arg(value_enum, long, default_value_t = Layout::Default)]
+    pub layout: Layout,
+
+    /// Shortcut for `layout='reverse'`
+    #[arg(long)]
+    pub reverse: bool,
+
+    /// Height of skim's window (--height 40%)
+    #[arg(long, default_value = "100%")]
+    pub height: String,
+
+    /// Disable height feature
+    #[arg(long)]
+    pub no_height: bool,
+
+    /// Minimum height when --height is given by percent
+    #[arg(long, default_value = "10")]
+    pub min_height: String,
+
+    /// Screen Margin (TRBL / TB,RL / T,RL,B / T,R,B,L)
+    /// e.g. `sk --margin 1,10%`
+    #[arg(long, default_values_t = vec!["0".to_owned(); 4])]
+    pub margin: Vec<String>,
+
+    /// Prompt string for query mode
+    #[arg(short, long, default_value = "> ")]
+    pub prompt: String,
+
+    /// Prompt string for command mode
+    #[arg(long, default_value = "c> ")]
+    pub cmd_prompt: String,
+
+    /* Display */
+    /// Parse ANSI color codes for input strings
+    #[arg(long)]
+    pub ansi: bool,
+
+    /// Number of spaces for a tab character
+    #[arg(long, default_value_t = 8)]
+    pub tabstop: usize,
+
+    /// Display STR next to info
+    #[arg(long)]
+    pub header: Option<String>,
+
+    /// The first N lines of the input are treated as header
+    #[arg(long, default_value_t = 0)]
+    pub header_lines: usize,
+
+    /// Display info next to query
+    #[arg(long)]
+    pub inline_info: bool,
+
+    /* History */
+    /// History file
+    #[arg(long)]
+    pub history: Option<PathBuf>,
+
+    /// Maximum number of query history entries
+    #[arg(long, default_value_t = 1000)]
+    pub history_size: usize,
+
+    /// Command History file
+    #[arg(long)]
+    pub cmd_history: Option<PathBuf>,
+
+    /// Maximum number of command history entries
+    #[arg(long, default_value_t = 1000)]
+    pub cmd_history_size: usize,
+
+    /* Preview */
+    /// Command to preview current highlighted line ({})
+    /// We can specify the fields. e.g. ({1}, {..3}, {0..})
+    #[arg(long)]
+    pub preview: Option<String>,
+
+    /// Preview window layout
+    /// [up|down|left|right][:SIZE[%]][:hidden][:+SCROLL[-OFFSET]]
+    #[arg(long, default_value = "right:50%")]
+    pub preview_window: String,
+
+    /* Scripting */
+    /// Specify the initial query
+    #[arg(short, long)]
+    pub query: Option<String>,
+
+    /// Specify the initial query for interactive mode
+    #[arg(long)]
+    pub cmd_query: Option<String>,
+
+    /// Comma seperated keys that can be used to complete skim
+    #[arg(long)]
+    pub expect: Vec<String>,
+
+    /// Read input delimited by ASCII NUL(\0) characters
+    #[arg(long)]
+    pub read0: bool,
+
+    /// Print output delimited by ASCII NUL(\0) characters
+    #[arg(long)]
+    pub print0: bool,
+
+    /// Do not clear screen on exit
+    #[arg(long)]
+    pub no_clear: bool,
+
+    /// Filter mode,
+    /// output the score and the item to stdout
+    #[arg(short, long)]
+    pub filter: Option<String>,
+
+    /// Print query as the first line
+    #[arg(long)]
+    pub print_query: bool,
+
+    /// Print command query as the first line (after --print-query)
+    #[arg(long)]
+    pub print_cmd: bool,
+
+    /// Print matching score in filter output (with --filter)
+    #[arg(long, requires = "filter")]
+    pub print_score: bool,
+
+    /// Automatically select the only match
+    #[arg(short = '1', long)]
+    pub select_1: bool,
+
+    /// Exit immediately when there's no match
+    #[arg(short = '0', long)]
+    pub exit_0: bool,
+
+    /// Synchronous search for multi-staged filtering
+    #[arg(long)]
+    pub sync: bool,
+
+    /// Pre-select the first n items in multi-selection mode
+    #[arg(long, default_value_t = 0)]
+    pub pre_select_n: usize,
+
+    /// Pre-select the matched items in multi-selection mode
+    #[arg(long, default_value = "")]
+    pub pre_select_pat: String,
+
+    /// Pre-select the matched items in multi-selection mode
+    #[arg(long)]
+    pub pre_select_items: Option<String>,
+
+    /// Pre-select the items read from file
+    #[arg(long)]
+    pub pre_select_file: Option<PathBuf>,
+
+    /* Removed */
+    /// Replace `replstr` with the selected item
+    #[arg(short = 'I')]
+    pub replstr: Option<String>,
+
+    /* Reserved (not used for now) */
+    #[arg(short = 'x', long)]
+    pub extended: bool,
+
+    #[arg(long)]
+    pub literal: bool,
+
+    #[arg(long)]
+    pub cycle: bool,
+
+    #[arg(long, default_value_t = 10)]
+    pub hscroll_off: usize,
+
+    #[arg(long)]
+    pub filepath_word: bool,
+
+    #[arg(long, default_value = "abcdefghijklmnopqrstuvwxyz")]
+    pub jump_labels: String,
+
+    #[arg(long)]
+    pub border: bool,
+
+    #[arg(long)]
+    pub no_bold: bool,
+}

--- a/src/engine/fuzzy.rs
+++ b/src/engine/fuzzy.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "cli")]
+use clap::ValueEnum;
+
 use std::fmt::{Display, Error, Formatter};
 use std::sync::Arc;
 
@@ -12,8 +15,11 @@ use bitflags::_core::cmp::min;
 
 //------------------------------------------------------------------------------
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "cli", derive(ValueEnum))]
 pub enum FuzzyAlgorithm {
+    #[cfg_attr(feature = "cli", value(name = "skim_v1"))]
     SkimV1,
+    #[cfg_attr(feature = "cli", value(name = "skim_v2"))]
     SkimV2,
     Clangd,
 }

--- a/src/engine/fuzzy.rs
+++ b/src/engine/fuzzy.rs
@@ -152,9 +152,7 @@ impl MatchEngine for FuzzyEngine {
             }
         }
 
-        if matched_result == None {
-            return None;
-        }
+        matched_result.as_ref()?;
 
         let (score, matched_range) = matched_result.unwrap();
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -6,7 +6,7 @@ use crate::item::ItemPool;
 use crate::theme::ColorTheme;
 use crate::theme::DEFAULT_THEME;
 use crate::util::{clear_canvas, print_item, str_lines, LinePrinter};
-use crate::{DisplayContext, Matches, SkimOptions};
+use crate::{DisplayContext, Layout, Matches, SkimOptions};
 use defer_drop::DeferDrop;
 use std::cmp::max;
 use std::sync::Arc;
@@ -44,14 +44,8 @@ impl Header {
     }
 
     pub fn with_options(mut self, options: &SkimOptions) -> Self {
-        if let Some(tabstop_str) = options.tabstop {
-            let tabstop = tabstop_str.parse::<usize>().unwrap_or(8);
-            self.tabstop = max(1, tabstop);
-        }
-
-        if options.layout.starts_with("reverse") {
-            self.reverse = true;
-        }
+        self.tabstop = max(1, options.tabstop.unwrap_or(8));
+        self.reverse = matches!(options.layout, Layout::Reverse | Layout::ReverseList);
 
         match options.header {
             None => {}

--- a/src/helper/item_reader.rs
+++ b/src/helper/item_reader.rs
@@ -73,10 +73,16 @@ impl SkimItemReaderOption {
         self
     }
 
-    pub fn with_nth(mut self, with_nth: &str) -> Self {
-        if !with_nth.is_empty() {
-            self.transform_fields = with_nth.split(',').filter_map(FieldRange::from_str).collect();
-        }
+    pub fn with_nth<I, S>(mut self, with_nth: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.transform_fields = with_nth
+            .into_iter()
+            .filter_map(|s| FieldRange::from_str(s.as_ref()))
+            .collect();
+
         self
     }
 
@@ -85,10 +91,16 @@ impl SkimItemReaderOption {
         self
     }
 
-    pub fn nth(mut self, nth: &str) -> Self {
-        if !nth.is_empty() {
-            self.matching_fields = nth.split(',').filter_map(FieldRange::from_str).collect();
-        }
+    pub fn nth<I, S>(mut self, nth: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.matching_fields = nth
+            .into_iter()
+            .filter_map(|s| FieldRange::from_str(s.as_ref()))
+            .collect();
+
         self
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -69,11 +69,9 @@ impl Input {
         }
     }
 
-    pub fn parse_expect_keys(&mut self, keys: Option<&str>) {
-        if let Some(keys) = keys {
-            for key in keys.split(',') {
-                self.bind(key, vec![Event::EvActAccept(Some(key.to_string()))]);
-            }
+    pub fn parse_expect_keys(&mut self, keys: &[&str]) {
+        for key in keys {
+            self.bind(key, vec![Event::EvActAccept(Some(key.to_string()))]);
         }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -38,12 +38,13 @@ impl Input {
     }
 
     pub fn bind(&mut self, key: &str, action_chain: ActionChain) {
-        let key = from_keyname(key);
-        if key == None || action_chain.is_empty() {
+        let Some(key) = from_keyname(key) else {
+            return;
+        };
+
+        if action_chain.is_empty() {
             return;
         }
-
-        let key = key.unwrap();
 
         // remove the key for existing keymap;
         let _ = self.keymap.remove(&key);

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,5 +1,8 @@
 ///! An item is line of text that read from `find` command or stdin together with
 ///! the internal states, such as selected or not
+#[cfg(feature = "cli")]
+use clap::ValueEnum;
+
 use std::cmp::min;
 use std::default::Default;
 use std::ops::Deref;
@@ -197,27 +200,18 @@ impl<'mutex, T: Sized> Deref for ItemPoolGuard<'mutex, T> {
 
 //------------------------------------------------------------------------------
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "cli", derive(ValueEnum))]
 pub enum RankCriteria {
     Score,
-    Begin,
-    End,
+    #[cfg_attr(feature = "cli", value(name = "-score"))]
     NegScore,
+    Begin,
+    #[cfg_attr(feature = "cli", value(name = "-begin"))]
     NegBegin,
+    End,
+    #[cfg_attr(feature = "cli", value(name = "-end"))]
     NegEnd,
     Length,
+    #[cfg_attr(feature = "cli", value(name = "-length"))]
     NegLength,
-}
-
-pub fn parse_criteria(text: &str) -> Option<RankCriteria> {
-    match text.to_lowercase().as_ref() {
-        "score" => Some(RankCriteria::Score),
-        "begin" => Some(RankCriteria::Begin),
-        "end" => Some(RankCriteria::End),
-        "-score" => Some(RankCriteria::NegScore),
-        "-begin" => Some(RankCriteria::NegBegin),
-        "-end" => Some(RankCriteria::NegEnd),
-        "length" => Some(RankCriteria::Length),
-        "-length" => Some(RankCriteria::NegLength),
-        _ => None,
-    }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -778,7 +778,7 @@ impl Model {
             .shrink(0);
         let win_header = Win::new(&self.header).grow(0).shrink(0);
         let win_query_status = HSplit::default()
-            .basis(if self.inline_info { 1 } else { 0 })
+            .basis(usize::from(self.inline_info))
             .grow(0)
             .shrink(0)
             .split(Win::new(&self.query).grow(0).shrink(0))

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,11 +1,10 @@
-use std::rc::Rc;
-
-use derive_builder::Builder;
-
 use crate::helper::item_reader::SkimItemReader;
+use crate::item::RankCriteria;
 use crate::reader::CommandCollector;
-use crate::{CaseMatching, FuzzyAlgorithm, MatchEngineFactory, Selector};
+use crate::{CaseMatching, FuzzyAlgorithm, Layout, MatchEngineFactory, Selector};
+use derive_builder::Builder;
 use std::cell::RefCell;
+use std::rc::Rc;
 
 #[derive(Builder)]
 #[builder(build_fn(name = "final_build"))]
@@ -15,20 +14,20 @@ pub struct SkimOptions<'a> {
     pub multi: bool,
     pub prompt: Option<&'a str>,
     pub cmd_prompt: Option<&'a str>,
-    pub expect: Option<String>,
+    pub expect: Vec<&'a str>,
     pub tac: bool,
     pub nosort: bool,
-    pub tiebreak: Option<String>,
+    pub tiebreak: Vec<RankCriteria>,
     pub exact: bool,
     pub cmd: Option<&'a str>,
     pub interactive: bool,
     pub query: Option<&'a str>,
     pub cmd_query: Option<&'a str>,
     pub regex: bool,
-    pub delimiter: Option<&'a str>,
+    pub delimiter: &'a str,
     pub replstr: Option<&'a str>,
-    pub color: Option<&'a str>,
-    pub margin: Option<&'a str>,
+    pub color: Vec<&'a str>,
+    pub margin: Vec<&'a str>,
     pub no_height: bool,
     pub no_clear: bool,
     pub no_clear_start: bool,
@@ -37,13 +36,13 @@ pub struct SkimOptions<'a> {
     pub preview: Option<&'a str>,
     pub preview_window: Option<&'a str>,
     pub reverse: bool,
-    pub tabstop: Option<&'a str>,
+    pub tabstop: Option<usize>,
     pub no_hscroll: bool,
     pub no_mouse: bool,
     pub inline_info: bool,
     pub header: Option<&'a str>,
     pub header_lines: usize,
-    pub layout: &'a str,
+    pub layout: Layout,
     pub algorithm: FuzzyAlgorithm,
     pub case: CaseMatching,
     pub engine_factory: Option<Rc<dyn MatchEngineFactory>>,
@@ -66,20 +65,20 @@ impl<'a> Default for SkimOptions<'a> {
             multi: false,
             prompt: Some("> "),
             cmd_prompt: Some("c> "),
-            expect: None,
+            expect: vec![],
             tac: false,
             nosort: false,
-            tiebreak: None,
+            tiebreak: vec![],
             exact: false,
             cmd: None,
             interactive: false,
             query: None,
             cmd_query: None,
             regex: false,
-            delimiter: None,
+            delimiter: "",
             replstr: Some("{}"),
-            color: None,
-            margin: Some("0,0,0,0"),
+            color: vec![],
+            margin: vec!["0"; 4],
             no_height: false,
             no_clear: false,
             no_clear_start: false,
@@ -94,7 +93,7 @@ impl<'a> Default for SkimOptions<'a> {
             inline_info: false,
             header: None,
             header_lines: 0,
-            layout: "",
+            layout: Layout::Default,
             algorithm: FuzzyAlgorithm::default(),
             case: CaseMatching::default(),
             engine_factory: None,
@@ -119,7 +118,7 @@ impl<'a> SkimOptionsBuilder<'a> {
         }
 
         if let Some(true) = self.reverse {
-            self.layout = Some("reverse");
+            self.layout = Some(Layout::Reverse);
         }
 
         self.final_build()

--- a/src/previewer.rs
+++ b/src/previewer.rs
@@ -464,7 +464,7 @@ where
                     .env("LINES", preview_cmd.lines.to_string())
                     .env("COLUMNS", preview_cmd.columns.to_string())
                     .arg("-c")
-                    .arg(&cmd)
+                    .arg(cmd)
                     .stdout(Stdio::piped())
                     .stderr(Stdio::piped())
                     .spawn();

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -14,6 +14,7 @@ use crate::orderedvec::OrderedVec;
 use crate::theme::{ColorTheme, DEFAULT_THEME};
 use crate::util::clear_canvas;
 use crate::util::{print_item, reshape_string, LinePrinter};
+use crate::Layout;
 use crate::{DisplayContext, MatchRange, Matches, Selector, SkimItem, SkimOptions};
 use regex::Regex;
 use std::rc::Rc;
@@ -93,18 +94,13 @@ impl Selection {
             self.multi_selection = true;
         }
 
-        if options.layout.starts_with("reverse") {
-            self.reverse = true;
-        }
+        self.reverse = matches!(options.layout, Layout::Reverse | Layout::ReverseList);
 
         if options.no_hscroll {
             self.no_hscroll = true;
         }
 
-        if let Some(tabstop_str) = options.tabstop {
-            let tabstop = tabstop_str.parse::<usize>().unwrap_or(8);
-            self.tabstop = max(1, tabstop);
-        }
+        self.tabstop = max(1, options.tabstop.unwrap_or(8));
 
         if options.tac {
             self.items.tac(true);

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -46,12 +46,11 @@ pub struct ColorTheme {
 }
 
 #[rustfmt::skip]
-#[allow(dead_code)]
 impl ColorTheme {
     pub fn init_from_options(options: &SkimOptions) -> ColorTheme {
         // register
-        if let Some(color) = options.color {
-            ColorTheme::from_options(color)
+        if !options.color.is_empty() {
+            ColorTheme::from_options(&options.color)
         } else {
             ColorTheme::dark256()
         }
@@ -170,9 +169,9 @@ impl ColorTheme {
     }
 
     #[allow(clippy::wildcard_in_or_patterns)]
-    fn from_options(color: &str) -> Self {
+    fn from_options(color: &[&str]) -> Self {
         let mut theme = ColorTheme::dark256();
-        for pair in color.split(',') {
+        for pair in color {
             let color: Vec<&str> = pair.split(':').collect();
             if color.len() < 2 {
                 theme = match color[0] {

--- a/src/util.rs
+++ b/src/util.rs
@@ -278,9 +278,7 @@ pub fn margin_string_to_size(margin: &str) -> Size {
 /// - `TB,RL`    Vertical, horizontal margin
 /// - `T,RL,B`   Top, horizontal, bottom margin
 /// - `T,R,B,L`  Top, right, bottom, left margin
-pub fn parse_margin(margin_option: &str) -> (Size, Size, Size, Size) {
-    let margins = margin_option.split(',').collect::<Vec<&str>>();
-
+pub fn parse_margin(margins: &[&str]) -> (Size, Size, Size, Size) {
     match margins.len() {
         1 => {
             let margin = margin_string_to_size(margins[0]);


### PR DESCRIPTION
## The construction of CLI

Use **clap-4.0.18** with **derive** feature.

The only way I know to reserve the old style of help information which mimicked [fzf](https://github.com/junegunn/fzf) is using [Command::override_help](https://docs.rs/clap/latest/clap/builder/struct.Command.html#method.override_help) with the help information written manually.

I write help for every argument and then modify the auto generated help information to get the final one.



## To developers:

1. `crate::cli::Cli` could parse string to type value(s) now, so it's no need to parse string in succeeding functions.

2. These **enum**s of arguments implementing [ValueEnum](https://docs.rs/clap/latest/clap/trait.ValueEnum.html),

   - `crate::engine::fuzzy::FuzzyAlgorithm`
   - `crate::item::RankCriteria`
   - `crate::CaseMatching`
   - And new enum `crate::Layout`

3. Some fields of `crate::options::SkimOptions` change types,

   - expect: `Option<&str>` => `Vec<&str>`
   - tiebreak: `Option<String>` => `Vec<RankCriteria>`
   - delimiter: `Option<&str>` => `&str`
   - color: `Option<&str>` => `Vec<&str>`
   - margin: `Option<&str>` => `Vec<&str>`
   - tabstop: `Option<&str>` => `Option<usize>`
   - layout: `&'a str` => `Layout`

4. For the above reasons, the ways to use `SkimOptions` change,

   - In `crate::input::Input`,
     - Before: `parse_expect_keys(&mut self, keys: Option<&str>)`
     - Now: `parse_expect_keys(&mut self, keys: &[&str])`

   - In `crate::item`, remove `parse_criteria`;

   - In `crate::theme::ColorTheme`,
     - Before: `from_options(color: &str) -> Self`
     - Now: `from_options(color: &[&str]) -> Self`

   - In `crate::util`,
     - Before: `parse_margin(margins: &str) -> (Size, Size, Size, Size)`
     - Now: `parse_margin(margins: &[&str]) -> (Size, Size, Size, Size)`

   - See `crate::header::with_options`, `crate::model`, `crate::selection`;



## To users of library

In `skim::prelude::SkimOptionsBuilder`

- **layout**:
  - Before: `layout(&mut self, value: &'a str) -> &mut Self`
  - Now: `layout(&mut self, value: skim::Layout) -> &mut Self`

In `skim::prelude::SkimItemReaderOption`

- **nth**:
  - Before: `nth(self, nth: &str) -> Self`
  - Now: `nth(self, nth: I) -> Self`

- **with_nth**:
  - Before: `with_nth(self, with_nth: &str) -> Self`
  - Now: `with_nth(self, with_nth: I) -> Self`