### PR TITLE
Partial fix CVE-2020-26235

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rayon = "1.5.3"
 derive_builder = "0.11.2"
 bitflags = "1.3.2"
 timer = "0.2.0"
-chrono = "0.4.22"
+chrono = { version = "0.4.22", default-features = false }
 crossbeam = "0.8.2"
 beef = "0.5.2" # compact cow
 defer-drop = "1.2.0"


### PR DESCRIPTION
This, in addition to https://github.com/Yoric/timer.rs/pull/24, should fix CVE-2020-26235 for `skim`.

This is required to fix: https://github.com/kimono-koans/httm/issues/54.