### PR TITLE
Fix CVE-2020-26235

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,11 +86,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.44",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -406,7 +403,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -734,7 +731,7 @@ dependencies = [
  "rayon",
  "regex",
  "shlex",
- "time 0.3.15",
+ "time",
  "timer",
  "tuikit",
  "unicode-width",
@@ -815,17 +812,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
@@ -837,8 +823,7 @@ dependencies = [
 [[package]]
 name = "timer"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d42176308937165701f50638db1c31586f183f1aab416268216577aec7306b"
+source = "git+https://github.com/Yoric/timer.rs#4ba32a90432c50224d5a2c447cb213e8432b10a8"
 dependencies = [
  "chrono",
 ]
@@ -895,12 +880,6 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,15 @@ rayon = "1.5.3"
 derive_builder = "0.11.2"
 bitflags = "1.3.2"
 timer = "0.2.0"
-chrono = "0.4.22"
+chrono = { version = "0.4.22", default-features = false }
 crossbeam = "0.8.2"
 beef = "0.5.2" # compact cow
 defer-drop = "1.2.0"
+
+# Patch with latest version
+# Maintainer has accepted PR but hasn't created a new crate
+[patch.crates-io]
+timer = { git = "https://github.com/Yoric/timer.rs" }
 
 [features]
 default = ["cli"]


### PR DESCRIPTION
This, in addition to https://github.com/Yoric/timer.rs/pull/25, should fix `cargo audit` flagging `skim` for CVE-2020-26235.

This is required to fully fix: https://github.com/kimono-koans/httm/issues/54.