### PR TITLE
Fix unresponsive query prompt while matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_str_bytes"
@@ -731,6 +731,7 @@ dependencies = [
  "lazy_static",
  "log",
  "nix 0.25.0",
+ "once_cell",
  "rayon",
  "regex",
  "shlex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ chrono = "0.4.22"
 crossbeam = "0.8.2"
 beef = "0.5.2" # compact cow
 defer-drop = "1.2.0"
+once_cell = { version = "1.16.0", default-features = false }
 
 [features]
 default = ["cli"]


### PR DESCRIPTION
Using a separate thread pool for the matching par_iter fixes any unresponsiveness while matching when using skim as a library.